### PR TITLE
test(k8s): CheckDestroy lists all resources used in test

### DIFF
--- a/scaleway/data_source_k8s_cluster_test.go
+++ b/scaleway/data_source_k8s_cluster_test.go
@@ -15,7 +15,11 @@ func TestAccScalewayDataSourceK8SCluster_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/scaleway/data_source_k8s_pool_test.go
+++ b/scaleway/data_source_k8s_pool_test.go
@@ -16,7 +16,11 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/scaleway/resource_k8s_cluster_test.go
+++ b/scaleway/resource_k8s_cluster_test.go
@@ -126,7 +126,10 @@ func TestAccScalewayK8SCluster_Basic(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SClusterConfigMinimal(previousK8SVersion),
@@ -179,7 +182,10 @@ func TestAccScalewayK8SCluster_Autoscaling(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SClusterConfigAutoscaler(latestK8SVersion),
@@ -252,7 +258,10 @@ func TestAccScalewayK8SCluster_OIDC(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SClusterConfigOIDC(latestK8SVersion),
@@ -319,7 +328,10 @@ func TestAccScalewayK8SCluster_AutoUpgrade(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SClusterAutoUpgrade(false, "any", 0, previousK8SVersion),
@@ -398,7 +410,10 @@ func TestAccScalewayK8SCluster_PrivateNetwork(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SClusterConfigPrivateNetworkLinked(latestK8SVersion),
@@ -460,7 +475,10 @@ func TestAccScalewayK8SCluster_TypeChange(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				// 1 : Start with a mutualized Kapsule cluster

--- a/scaleway/resource_k8s_pool_test.go
+++ b/scaleway/resource_k8s_pool_test.go
@@ -21,7 +21,12 @@ func TestAccScalewayK8SCluster_PoolBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.minimal"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigMinimal(latestK8SVersion, false),
@@ -73,7 +78,12 @@ func TestAccScalewayK8SCluster_PoolWait(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.minimal"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigWait(latestK8SVersion, false, 0),
@@ -143,11 +153,18 @@ func TestAccScalewayK8SCluster_PoolWait(t *testing.T) {
 func TestAccScalewayK8SCluster_PoolPlacementGroup(t *testing.T) {
 	tt := NewTestTools(t)
 	defer tt.Cleanup()
+
 	latestK8SVersion := testAccScalewayK8SClusterGetLatestK8SVersion(tt)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.placement_group"),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.placement_group_2"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigPlacementGroup(latestK8SVersion),
@@ -199,7 +216,11 @@ func TestAccScalewayK8SCluster_PoolUpgradePolicy(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.upgrade_policy"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigUpgradePolicy(latestK8SVersion, 2, 3),
@@ -250,7 +271,11 @@ func TestAccScalewayK8SCluster_PoolKubeletArgs(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.kubelet_args"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigKubeletArgs(latestK8SVersion, 1337),
@@ -285,7 +310,11 @@ func TestAccScalewayK8SCluster_PoolZone(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.zone"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckScalewayK8SPoolConfigZone(latestK8SVersion, "fr-par-2"),
@@ -310,7 +339,11 @@ func TestAccScalewayK8SCluster_PoolSize(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.pool"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -383,7 +416,11 @@ func TestAccScalewayK8SCluster_PoolPrivateNetwork(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.pool_with_pn"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -436,7 +473,14 @@ func TestAccScalewayK8SCluster_PoolPublicIPDisabled(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
+			testAccCheckScalewayVPCPublicGatewayDestroy(tt),
+			testAccCheckScalewayVPCPublicGatewayDHCPDestroy(tt),
+			testAccCheckScalewayVPCGatewayNetworkDestroy(tt),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.public_ip"),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c2883f0-105a-4b41-bbc0-508fecd7f57a
+      - db1ed812-300d-4590-910d-2f0b53eee818
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "707"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e2ddbf0-b919-4310-be18-baeebdc1a974
+      - ea6aa712-95d9-4f71-b5ab-1c555cb2a121
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "707"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775bfc66-e9f4-4d9e-9d04-449725208c35
+      - 99a48593-94b7-4589-8b5d-b7093f96cb83
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757107Z","created_at":"2023-11-07T16:20:01.429757107Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.443794941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141690756Z","created_at":"2023-11-10T13:16:59.141690756Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:16:59.157804850Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1460"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2234c669-dd89-4343-829e-6a764baa4a25
+      - 6d3c51e0-d5be-41b0-9648-b91ffd5df954
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.443795Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:16:59.157805Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1496"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d53be89b-da64-4b33-930f-f642ea334604
+      - d4058dce-a61f-49f6-a475-e8ff39ae33cc
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1970d9f1-e5f7-4179-a5ba-583c75f09109
+      - 9ea16892-11ac-47cf-9260-894d2f5fdd93
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae88fe6e-923a-4c4f-b5c5-6e3333397d35
+      - df13c059-f895-4bd3-a661-a25c63e3d7b4
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab6ea085-ab94-41cf-9b06-09f27c7fa1e0
+      - 78d64b66-5bd9-4561-9e00-31d6f9085d0e
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a1ce982-aaed-47e7-8dd1-3a571ea5a5ee
+      - f2c5799b-d99e-433e-9398-60f1bca9e987
     status: 200 OK
     code: 200
     duration: ""
@@ -316,16 +316,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1487"
+      - "1533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 369ee6ed-c00d-4133-9546-42d2a139eeb5
+      - b47d1050-c755-4f2e-8011-9e09d5de0b9e
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bb7ba8e-b8e0-452f-8df8-a41f3e605d4c
+      - b3bd8766-ace6-48d9-ac3a-1ba447c5c0fc
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eab4a68-00af-4088-83dd-fed35d5dac6f
+      - 867cd00d-2b5a-4bdb-b550-c5b5d27e71c9
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b77a1f5-c294-4f49-aadf-01178d9855d5
+      - 23a70e29-052f-4228-aae5-8f76d9f3465b
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9cb1463-bf6d-4de9-a631-2f013abdf3d7
+      - 5d74e8a9-0241-4ccd-8e4f-d454a5ac9566
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855399Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578003971Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "597"
+      - "620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcea6407-7376-4945-9758-92db32fdada8
+      - 6a6b9a28-0f60-4137-bcac-986aaad2f778
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69335d98-2581-42e0-88fb-63612e40191e
+      - d227efd5-023e-4f56-9242-215062917e4c
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:12 GMT
+      - Fri, 10 Nov 2023 13:17:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f80ceff-7b3d-484d-89da-945a205e98cc
+      - aba53479-09af-4ad2-9213-11ace9e9ff75
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:17 GMT
+      - Fri, 10 Nov 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d05a470-5724-4fff-8852-ddcc2a22f97c
+      - 422cb3f0-c922-46c7-b5d4-95643714445c
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 603f9f65-0d7b-46cc-9517-1271bca55acf
+      - 6619a5eb-5220-4fef-b99f-b026ecaef940
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3940957-f55b-4b68-9fa6-1bfa3ba28174
+      - 66417451-b8c5-4efc-af85-4e7f3fb05faa
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:32 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ee46eb7-d7ac-478e-b2a4-c44d628dcb0a
+      - 133f50d4-4584-4480-bea3-78eb0c1cd0fc
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:37 GMT
+      - Fri, 10 Nov 2023 13:17:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ab59beb-83b1-4ce3-86a2-8befcfd0b0b0
+      - a05a1755-1406-42c9-b6a2-6642ba9b6b5a
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:42 GMT
+      - Fri, 10 Nov 2023 13:17:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 795158bd-768b-41f7-979d-c829ebe88fb6
+      - 3589771f-92d2-434f-83ec-e137fed8dc6d
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:47 GMT
+      - Fri, 10 Nov 2023 13:17:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6be204a-2e9c-48fd-bca0-f1d83aeb65f0
+      - aa2ac838-6333-4efc-b5b4-d6d793b46800
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:52 GMT
+      - Fri, 10 Nov 2023 13:17:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ad377b5-6524-41ed-97cf-f777059e747a
+      - 0172b3b0-4bba-4329-8a3a-71a944652ec8
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:57 GMT
+      - Fri, 10 Nov 2023 13:17:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 835b0df3-e565-4a35-a239-76102ac070c4
+      - 69c52c06-dda9-45b3-8190-355b1f5b5d85
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:02 GMT
+      - Fri, 10 Nov 2023 13:18:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 213f11f4-77e6-4e1b-b5f8-ffe6d5de7c0c
+      - d6dc8dec-03d1-46ff-85c1-af2e76db29f7
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:07 GMT
+      - Fri, 10 Nov 2023 13:18:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50a3b175-37d3-4da4-9373-82a7d6b69eaf
+      - 24f63fb7-3331-4b11-9bad-d66affdbce18
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:13 GMT
+      - Fri, 10 Nov 2023 13:18:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56aab85-ef73-431a-bb9f-f70b549236bd
+      - 5b6300fe-48fb-41ef-ba63-d38ba79d30fa
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:18:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0698cef1-d089-4d33-af61-d5a381c18ae3
+      - 48d084b5-9e08-4cd7-854e-2ec66688243e
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:23 GMT
+      - Fri, 10 Nov 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bb2e6bc-7742-46f4-bd86-622809b2dbb7
+      - c3458f5e-05c3-415b-ada7-b334eb719ff9
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:28 GMT
+      - Fri, 10 Nov 2023 13:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b53be367-2541-4c4b-b883-962ef2d6e67d
+      - 7fcd5e36-ca06-42a1-bc69-83c95a2d1900
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:33 GMT
+      - Fri, 10 Nov 2023 13:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d73a8ec8-6ae8-47b8-b122-f3ec6cfdd113
+      - cbcb9eba-15e4-4ec5-93c3-dff63f4b89c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:38 GMT
+      - Fri, 10 Nov 2023 13:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82b9e3a8-5c78-4127-9cca-c5c38d5e7784
+      - 0cdebcd5-b771-4290-8297-74f0b2fb2b9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a3cad23-9def-4800-868e-081e09f7a6d9
+      - 710b33c3-f603-4e21-befe-62b0bb862898
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:48 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c43172c8-b305-41fa-b395-6c14361d4a33
+      - 629f6a3e-7aa0-4754-9bc0-c68fece5e97c
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:53 GMT
+      - Fri, 10 Nov 2023 13:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c479a4e-7cfc-4aa4-9d93-8571b9d5f071
+      - 1f54af78-61f2-4aa1-aab0-2ae5e5c21e3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:58 GMT
+      - Fri, 10 Nov 2023 13:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fda1c472-d854-4c92-91f7-650d4fceaff4
+      - 93e004a0-656c-4c5d-bcb9-5d3417ac6ca4
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:03 GMT
+      - Fri, 10 Nov 2023 13:19:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 382935c4-9fd8-4b93-9180-8e18ae9ed57d
+      - 10f81494-f6b1-42f1-b051-6a48e5e080ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:08 GMT
+      - Fri, 10 Nov 2023 13:19:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2ccb154-05f3-4488-852a-2a6bc7d56056
+      - dbaaa82e-de39-49cd-96b9-fca03dda21fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:13 GMT
+      - Fri, 10 Nov 2023 13:19:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b10379a7-4c92-4774-9295-162786a1b3e8
+      - c7a34a74-6d80-4009-aba7-e4ffcca99ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:18 GMT
+      - Fri, 10 Nov 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8621ee7-6a0b-4d9c-9c55-e0e670791c67
+      - 23f7b492-e05f-40b1-a76d-78ba00a1b46f
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:23 GMT
+      - Fri, 10 Nov 2023 13:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 019e1b14-bde9-4563-94c0-075947df8992
+      - cbb71d85-8d13-41d5-b442-6e13966df389
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:28 GMT
+      - Fri, 10 Nov 2023 13:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6241920b-578d-46c8-a683-d67f27796c04
+      - 6bba9049-df93-469d-8f30-315cd0092b6a
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:33 GMT
+      - Fri, 10 Nov 2023 13:19:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 988665c1-1654-465a-9e69-02d99aa6bfb9
+      - 9097e431-4000-40aa-97b1-040e46e40107
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:39 GMT
+      - Fri, 10 Nov 2023 13:19:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cb7a3cd-89a2-42e0-9b89-4ee383d3c66b
+      - 2458201f-6948-4a0e-9896-0e3ba40b01be
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:44 GMT
+      - Fri, 10 Nov 2023 13:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28f0eb1a-ce15-4776-947c-4dc1c66e1237
+      - 1b920f7f-25a9-4c31-9aa7-19adaa204c19
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:49 GMT
+      - Fri, 10 Nov 2023 13:19:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf2db1fc-3813-41e1-8edb-3eafd402d3a2
+      - faa8a6c6-ef8c-4ddc-b230-98fe0ed3b735
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:54 GMT
+      - Fri, 10 Nov 2023 13:19:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16082489-e337-428e-a6d6-e9c15285ade9
+      - 83cf17c2-0907-4742-8521-b6e47e5d7a3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:59 GMT
+      - Fri, 10 Nov 2023 13:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b022712b-66de-447d-9b2b-dbcc3d20f9cc
+      - a28a1a5a-94aa-4ebd-a1ff-855474f8a5c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:04 GMT
+      - Fri, 10 Nov 2023 13:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 728c1ef7-2bf6-4106-9508-2e474f7d0c7d
+      - ec1b1bc3-65c7-4e5b-adfc-4db08636e690
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:09 GMT
+      - Fri, 10 Nov 2023 13:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ae1ba17-3406-4ea1-8ff3-cfd196911e3f
+      - 2a745343-adb8-4ba0-bd0d-10011a9dc760
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:14 GMT
+      - Fri, 10 Nov 2023 13:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7406aaa-fadf-4e2a-80fe-8992bac0d437
+      - 17d8fa22-a73c-4206-b6ad-ba44deacf7ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:19 GMT
+      - Fri, 10 Nov 2023 13:20:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0cf5c7d-80de-4f12-bebb-c8ac74109cc0
+      - 28b18137-a6c3-4ad4-aa81-b4a2b841fd14
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:24 GMT
+      - Fri, 10 Nov 2023 13:20:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b164586e-722b-4a97-9678-f459a67d4361
+      - 28ded471-d892-4837-bc5f-85e7403455cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:29 GMT
+      - Fri, 10 Nov 2023 13:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17d61080-503f-42d8-86e2-c441488d2104
+      - c374a179-eb03-478c-ae4e-8775da0fcb43
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:34 GMT
+      - Fri, 10 Nov 2023 13:20:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3350176-4947-401d-9671-aa541958dea8
+      - ef80fca4-6ec1-4e30-a34c-7323a40dade7
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:39 GMT
+      - Fri, 10 Nov 2023 13:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 631aac33-bb36-4b02-a628-230bf698cb85
+      - b53a10f6-c7df-4ff7-b443-65b88c6f8877
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:44 GMT
+      - Fri, 10 Nov 2023 13:20:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afd4da7a-afcc-44b5-815b-65853f1b146e
+      - e168a2a6-572b-4555-8d81-0a5ea7ef545b
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:49 GMT
+      - Fri, 10 Nov 2023 13:20:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56f3d987-da78-4a19-a909-16cd1fe08114
+      - addf1f8f-e197-4fb4-ae17-40e55bde8988
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:54 GMT
+      - Fri, 10 Nov 2023 13:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48c28c46-875f-4d6f-bc72-4979d595bc4a
+      - dbe101fb-8cfc-45bf-9d07-f573061d6ef3
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:59 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03835832-fc5c-4489-bc5e-6512e9b08d02
+      - 3f5c7cc2-e1ad-4fe5-9a9e-1fdb26fa6667
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:21:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3294d60d-2f16-4673-bd6f-00d49b34b1c9
+      - 7f8c265a-595c-4b79-ad7b-f3671fe9079e
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:09 GMT
+      - Fri, 10 Nov 2023 13:21:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41a1617e-b1ff-44ab-b778-94d0813991c9
+      - fa99eb35-7893-45e9-b3b8-85ac47196e71
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "594"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:14 GMT
+      - Fri, 10 Nov 2023 13:21:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c244eda8-32c9-45a2-b7b5-41cdeba0e7f7
+      - 81d81447-a0f4-4fc6-afa8-ebc85b57aebb
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81150f28-9af3-4b2b-ae63-dc44b2c30381
+      - 6a04bcda-d350-4d87-bedf-a83f07e79e6d
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1448"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f28f5f28-4c66-457c-90ba-dc1e6a57d17f
+      - 31d31176-54d5-4141-9096-900bbf1f0e2b
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57eab985-08f6-4598-8ee2-6b6621644750
+      - 11ab5d26-f1ee-4644-82fa-16e297ad6882
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/nodes?order_by=created_at_asc&page=1&pool_id=1fe1c124-6977-4948-8f6c-f2b823fcb286&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:05.112095Z","error_message":null,"id":"59d458d7-02a0-4bf8-9a0f-81f28c5fe2ec","name":"scw-tf-cluster-default-59d458d702a04bf89a0f81f","pool_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","provider_id":"scaleway://instance/fr-par-1/95a640e5-d685-44db-8a30-1dc37002649b","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:24:18.723499Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ca45a1a-061f-4dac-8f0b-ad6e72378e3a
+      - 1e767c1f-e896-4b26-922a-959e47701bd5
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1448"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b187d8a1-9d5f-4ce4-b4bf-2bcbda8da763
+      - 555a241c-52b2-44b2-9326-5419d20e9d79
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1448"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd3dda0-3f83-4d19-9fc4-8e06ae0ff1d6
+      - 7d1a802a-5d67-4c83-bea3-a5b545b55018
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1448"
+      - "617"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:21:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,568 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c984a56-7b8f-413d-8207-39148e4fc32a
+      - 1c56fc88-f898-4278-a2db-c1b3c49c23a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00489b34-74f4-44b2-9aa1-730aa7385443
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8fcb4fb-7d19-43b6-bb48-9152e98ad0cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 033601cd-7a5a-407d-bf42-83ba34332018
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a49ce3e-f408-4bc0-b834-38963ad6fa91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb815c4a-1e38-453b-b7a1-b60700ca0b3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1383e3cb-7bd8-46f5-b5d7-aa0bde0b6892
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8413b236-9aeb-4ac8-8bb6-0a18a777e86b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb8357e4-41de-4849-aa00-c6670fe99039
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7f66b27-3f05-4616-b5a9-e59b3ee6e888
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee6c426d-da33-4640-a490-74ba943a5e63
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "617"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85f20e88-e1e8-423c-bd95-684b93f323b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "615"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d2a584d7-b863-46b6-9738-ad246bcb0af7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f226eb86-2574-4c3e-9374-e23c1f97cf89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "615"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 087a92a5-4c42-4726-81e3-0e285c8a2c45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/nodes?order_by=created_at_asc&page=1&pool_id=6b36e370-15bb-4229-be44-a68b2a5cff3a&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:54.677Z","error_message":null,"id":"acd0b331-06d2-4905-ab09-320f7cb69c79","name":"scw-tf-cluster-default-acd0b33106d24905ab09320","pool_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","provider_id":"scaleway://instance/fr-par-1/10e84246-1002-4357-a749-80dcdd74a4c9","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:49.539023Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "657"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9c4091c-e789-48fb-8f0c-5a53d1a9e2d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 81426cd4-b9f2-4423-8a0c-bef1e28c0837
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d02325d6-3c02-404b-bee1-704ceb52ae53
     status: 200 OK
     code: 200
     duration: ""
@@ -2397,16 +2958,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1479"
+      - "3022"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c085b071-7635-4aa1-a222-bb77a25d909f
+      - 002f80c7-5e8d-4918-ac85-ffff2e4dd927
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2988,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1448"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e952bed9-6a75-45c3-959d-0ebf1729b567
+      - 7a4f2cc9-b4c4-47ce-b707-8c171c24dd74
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +3021,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2572"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eacbc34-efcb-410a-a5e2-19186131c379
+      - de782c0d-f926-40ef-bd1b-ab290bc75bef
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +3054,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:20 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c254d005-b316-4d83-af9d-d37541ebf194
+      - 2d3f9537-70bf-4b30-8855-39fc994084f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +3087,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "707"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65839107-a1a8-4789-9626-b5336307aa97
+      - 7806252b-47dd-4d14-b537-afd1270ab222
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +3120,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1448"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d0a70af-6a33-444e-bd6c-b04e8af75b31
+      - d34b929f-fdfe-4c53-b8b6-7c7cf4dac3e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +3153,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2572"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0fb3268-a4a4-4b98-a1c0-f612ba393625
+      - 19a0c908-3a9e-4027-a4a0-064c1cd3ddfd
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +3186,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "592"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +3208,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b383d50-3aa4-413c-a5ce-7796e09c8d1c
+      - 9a463e45-093c-4c0b-8152-6f40c812c9cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "615"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16dae40c-fb21-41d9-ab2e-d67d940d4d0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a30d882-0a49-49d0-987e-9c4518c3d7ea
     status: 200 OK
     code: 200
     duration: ""
@@ -2661,16 +3288,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1479"
+      - "3022"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cfc340d-ba47-4480-a69b-49ced9de8b46
+      - 391e8e04-5f4a-46f7-8d99-a7f59886fb4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,19 +3318,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/nodes?order_by=created_at_asc&page=1&pool_id=6b36e370-15bb-4229-be44-a68b2a5cff3a&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:54.677Z","error_message":null,"id":"acd0b331-06d2-4905-ab09-320f7cb69c79","name":"scw-tf-cluster-default-acd0b33106d24905ab09320","pool_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","provider_id":"scaleway://instance/fr-par-1/10e84246-1002-4357-a749-80dcdd74a4c9","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:49.539023Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1448"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f6662b3-c830-431f-b50a-a9c33eca77c1
+      - 09f758d8-6b16-4c13-8a7c-61ab28c849e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2724,19 +3351,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1448"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2395bb7b-8d5a-473c-9d0f-b23767b7e710
+      - b489faaa-a417-4f31-9e8d-c01dec1aa754
     status: 200 OK
     code: 200
     duration: ""
@@ -2757,19 +3384,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/nodes?order_by=created_at_asc&page=1&pool_id=1fe1c124-6977-4948-8f6c-f2b823fcb286&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:05.112095Z","error_message":null,"id":"59d458d7-02a0-4bf8-9a0f-81f28c5fe2ec","name":"scw-tf-cluster-default-59d458d702a04bf89a0f81f","pool_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","provider_id":"scaleway://instance/fr-par-1/95a640e5-d685-44db-8a30-1dc37002649b","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:24:18.723499Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "641"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +3406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d82b708f-28a8-4224-8adb-2efbbead04b9
+      - 78fa5ac6-3d1b-4dfd-b61e-d665bb5b44a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2790,19 +3417,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +3439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c164cf-99f4-4413-b7be-9ec3afa089d5
+      - da6f8b97-f66c-4758-b662-afc6e7d37e68
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,19 +3450,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2572"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,40 +3472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 553f56bd-50b7-4794-be24-833cfc4ffb4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 565ee76a-687b-4e22-9e39-ffebb59f17eb
+      - 5273d7bc-0627-4fa3-8c4f-8317f5b7c768
     status: 200 OK
     code: 200
     duration: ""
@@ -2892,16 +3486,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1479"
+      - "3022"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +3505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72ff8a88-5a73-4e13-9386-44c6b7d1d802
+      - 12c7c594-699f-49e3-9992-87b75db8e2ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2922,19 +3516,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1448"
+      - "1493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +3538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed82c34d-a562-4b68-bd39-ab384d564aee
+      - 18dde832-8f52-4235-8fe9-41c0270d0fe8
     status: 200 OK
     code: 200
     duration: ""
@@ -2955,19 +3549,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +3571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a15317ad-5d98-4abe-94c8-444adec45cdd
+      - f129b120-e5e0-4ac8-b2ac-b1de38b2137b
     status: 200 OK
     code: 200
     duration: ""
@@ -2988,19 +3582,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2572"
+      - "2574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3010,7 +3604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810d6ab1-cb34-4967-a11e-9f0e3ffc5fcc
+      - 63d59077-83c4-4dd7-88e2-0920cc44b685
     status: 200 OK
     code: 200
     duration: ""
@@ -3021,19 +3615,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356407608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013994571Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "598"
+      - "621"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:22 GMT
+      - Fri, 10 Nov 2023 13:22:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3043,7 +3637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 106afea7-0b1c-4721-8df1-b6a0f285c474
+      - 826e278d-73d1-484f-821f-a82dcb433fce
     status: 200 OK
     code: 200
     duration: ""
@@ -3054,19 +3648,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:22 GMT
+      - Fri, 10 Nov 2023 13:22:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3076,7 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22be75df-3ebe-4767-bed7-ed6cf72076dc
+      - d35fa23b-7031-4fd6-a28f-052789e0c3b2
     status: 200 OK
     code: 200
     duration: ""
@@ -3087,19 +3681,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:27 GMT
+      - Fri, 10 Nov 2023 13:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3109,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfed8573-6ed9-483f-9fcd-80f584df6311
+      - 5b4e0571-05f2-4a7b-916a-acba666dd56a
     status: 200 OK
     code: 200
     duration: ""
@@ -3120,19 +3714,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:23:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3142,7 +3736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77b3b7e6-2811-4851-b7e0-3766534d45f4
+      - b9d121ac-9eaa-4771-87e0-a65fe964b854
     status: 200 OK
     code: 200
     duration: ""
@@ -3153,19 +3747,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:37 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3175,7 +3769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f49fe20-7b88-4806-996b-db35328c4e03
+      - e754b677-ef38-4161-a11f-57e6a61f1d5b
     status: 200 OK
     code: 200
     duration: ""
@@ -3186,10 +3780,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "618"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5611d7c-b83b-4145-8ed3-826627bcc008
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3198,7 +3825,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:42 GMT
+      - Fri, 10 Nov 2023 13:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3208,7 +3835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ee345bc-4dd5-4707-aaaa-d35704081c06
+      - 6f12343a-af09-4eab-9731-4dde357b7033
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3219,19 +3846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721863802Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553357Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:42 GMT
+      - Fri, 10 Nov 2023 13:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3241,7 +3868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93f62be5-244b-40ab-b647-8d0f2489de89
+      - 9e02dfb5-2508-45bb-b941-c2cfabf8f4fc
     status: 200 OK
     code: 200
     duration: ""
@@ -3252,19 +3879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721864Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1496"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:43 GMT
+      - Fri, 10 Nov 2023 13:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3274,7 +3901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c60b72-5cd9-4ff4-94ca-7de1cee154da
+      - 3d8287c0-71ef-4855-9848-72961e92c4d4
     status: 200 OK
     code: 200
     duration: ""
@@ -3285,19 +3912,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721864Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1496"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:48 GMT
+      - Fri, 10 Nov 2023 13:23:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3307,7 +3934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad76cef8-caad-4cec-9f8b-6fe49fed20ef
+      - f2861e31-4088-47c1-816a-6327f3f94687
     status: 200 OK
     code: 200
     duration: ""
@@ -3318,10 +3945,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3330,7 +3957,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:53 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3340,7 +3967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5562762a-15c9-4d87-ba1a-f24616387e18
+      - be32a83f-5dc7-41e4-a627-fba220a9b5c6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3351,10 +3978,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c230f16e-9326-4410-a133-9c0ecadde48a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3363,7 +3990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:53 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3373,7 +4000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8103f77-33a6-42a5-b7c8-dbadaae7aece
+      - 075c3544-e899-4530-b98c-447502809c81
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3384,19 +4011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:53 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3406,7 +4033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9d709d1-80db-4994-bf88-a2f2fb8eecba
+      - 1746aa09-85ac-4a7e-af97-511e5271ad53
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3417,10 +4044,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3429,7 +4056,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:53 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3439,7 +4066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bab3bb3d-d15b-414b-a65f-c0a194384bc0
+      - 34216f58-59b1-464b-bf84-d033a416b9ef
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3450,10 +4077,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3462,7 +4089,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:53 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3472,7 +4099,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4eff59e-390e-4e3a-9d8c-79553de5a8c2
+      - dc4fe4c1-d22d-4c36-a237-1dbd93986431
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61e0a550-5c84-47e1-911a-670954d60292
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ba9a5d4-e26f-439e-a7a8-bedbd9f69bc4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:13 GMT
+      - Fri, 10 Nov 2023 13:20:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b1ab61b-33ba-4884-9b38-2c2adbbd4b02
+      - 95c70dd7-244f-4acc-ae59-7d0f43d58d44
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:14 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7de1a0fc-19d7-417b-9455-12d70fd47bb9
+      - 850f8cb2-476e-4356-a107-0c702b8a5d93
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: GET
   response:
-    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:15 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c36760dc-4f55-4b28-a0bf-cb5867c53190
+      - 219ba511-e211-4c41-92f6-6d9799521ecf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312569940Z","created_at":"2023-11-08T09:10:15.312569940Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:15.332112061Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414032Z","created_at":"2023-11-10T13:20:21.287414032Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:21.300261653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1462"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:15 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b991cf0-902b-4745-a6a3-77897abff593
+      - 91e2fde2-60f0-4212-9d40-f9d0cf46c353
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:15.332112Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:21.300262Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:15 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4756c8db-605d-4aaf-83d9-137e5942bafc
+      - 1351af8c-92b0-4bd5-9ff5-4004c4c3eb5c
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:20 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d13686f-dca5-4cd0-bddd-e39f73bed267
+      - 17e23893-5052-4179-bd3e-10da977529a3
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:20 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35e6325f-18ff-4e44-8cbe-b87317443099
+      - b80d2e48-fbc8-4f1d-857c-7ea8dce52167
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2612"
+      - "2614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:20 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50835ab1-4585-4a61-a853-b7f64da00860
+      - 8d1583e7-be9a-40e9-96d0-ad8f251593c0
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:20 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f061157a-52b2-4a34-9c38-3390f8536e4b
+      - f5f9a727-4e2d-4088-8ee7-b8aec19b3f94
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819065Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736439781Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:21 GMT
+      - Fri, 10 Nov 2023 13:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6f89475-a657-4b8f-a42c-c43a08533e2a
+      - e0392ede-d696-495a-83c3-a4d92f0ebc93
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:21 GMT
+      - Fri, 10 Nov 2023 13:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57901a7d-00cc-44f6-97dc-0d09684fa1b7
+      - 05f73793-b6f6-4222-be56-73741130691c
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:26 GMT
+      - Fri, 10 Nov 2023 13:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3820876-dc4b-4f93-bc7f-c44d709f26c1
+      - 2d74c048-c759-492c-93d5-69b3916990a2
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:31 GMT
+      - Fri, 10 Nov 2023 13:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d24b1e5-3baf-4a0c-80a1-9b94a2a9fe97
+      - 7e5ae8f1-9c22-4638-9fbb-17ef49146770
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:36 GMT
+      - Fri, 10 Nov 2023 13:20:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ad9bd8e-e958-4dc6-8039-8aeb8359c742
+      - eda4121a-c62d-4f13-ba80-5877da4ebd47
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:41 GMT
+      - Fri, 10 Nov 2023 13:20:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cee0d70d-572c-4fc8-b520-74aa244ee07e
+      - 8dd02ce5-7120-4a1a-b15d-ad647d91c780
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:46 GMT
+      - Fri, 10 Nov 2023 13:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb92b12c-1cfc-4011-a455-b769bc8ececc
+      - 2a969165-7635-4619-9f41-f84f0bb2bff2
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:51 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d22050f3-fd58-45cc-a88a-c6e0825024bf
+      - 66a0a6a8-a6c9-411c-9b67-42235d794f9b
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:10:56 GMT
+      - Fri, 10 Nov 2023 13:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b84d9c5-e364-44fb-8b30-5625e65bf56e
+      - 4576e574-49ee-48f7-9491-57093eb74619
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:01 GMT
+      - Fri, 10 Nov 2023 13:21:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eee7bd25-eeec-4e84-9126-157976dad202
+      - 0a83e6be-273f-44d3-b151-b0320a3b8be1
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:06 GMT
+      - Fri, 10 Nov 2023 13:21:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bff2d326-aa5e-43b3-b20d-1b77ad4ba7fe
+      - 27b214a1-7193-433a-b30b-e6b61088264d
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:11 GMT
+      - Fri, 10 Nov 2023 13:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17f82b79-183f-4413-99c7-e063b2b6f4dd
+      - bbd6f4ba-c2e4-4c1d-8252-8149b207004c
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:16 GMT
+      - Fri, 10 Nov 2023 13:21:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 245527ef-c30c-45fe-b84b-aa89dec72858
+      - 0d6e99b5-d06a-42e7-a1a9-d1bffcddf579
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:21 GMT
+      - Fri, 10 Nov 2023 13:21:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5a04c68-2f74-449d-a703-88ec6a2399fd
+      - 8c111de0-23ad-4e17-a844-15fe6fdaa524
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:26 GMT
+      - Fri, 10 Nov 2023 13:21:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec8e5370-dc19-42ab-b69c-641e3f69c7bb
+      - 2575cc44-51e9-4ead-8fc3-3ed53d8c502b
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:31 GMT
+      - Fri, 10 Nov 2023 13:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c52ec2a6-76b3-4e28-8b3b-76faed305eb5
+      - df024beb-a082-4b8f-b020-e8e13c790e3c
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:36 GMT
+      - Fri, 10 Nov 2023 13:21:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a24d1e4-d96f-40e7-a84d-56ee7cede418
+      - 41f4a019-bcd6-4fc1-a494-040fc8ed22a8
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:41 GMT
+      - Fri, 10 Nov 2023 13:21:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95bbba9d-35d3-458b-8fab-226190e6f864
+      - 817ccb47-b529-4e0f-b662-fa116f62d8ef
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:47 GMT
+      - Fri, 10 Nov 2023 13:21:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01ba471b-eecb-452f-ad42-cb5d5ba8d46f
+      - 146550e7-87b5-44bf-aba0-d1c8b3a6c7c9
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:52 GMT
+      - Fri, 10 Nov 2023 13:21:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4786950-f49a-4c3e-b1f5-3d188ddf1ff9
+      - d5e962f2-ae7e-4245-8c11-cd798fdddc4c
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:11:57 GMT
+      - Fri, 10 Nov 2023 13:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30eb7132-c3cc-482d-9428-031d3c68f5d2
+      - 6b8a9733-de4d-4f42-b2ba-8ac3ad9ff3c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:02 GMT
+      - Fri, 10 Nov 2023 13:22:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1df23190-ba70-4ea5-9621-2f20f60038cd
+      - e9e02ac0-ce9b-404c-a793-0f48df5b941e
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:07 GMT
+      - Fri, 10 Nov 2023 13:22:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f643ed1e-0e5b-4207-aa00-886086af41dc
+      - 97fd0392-b35e-45d1-914f-64222c9047ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:12 GMT
+      - Fri, 10 Nov 2023 13:22:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccb8f406-f9df-4d0b-a9c2-4222d5b67cf8
+      - 81ebf0ed-e44e-4ed2-89e6-1b4b6d191dbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:17 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a973318-b7f5-4288-8980-b4cd916193f9
+      - c44c4e35-63fd-4831-b688-7b6f409c28b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:22 GMT
+      - Fri, 10 Nov 2023 13:22:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 330a7d19-2769-45e0-b33b-0a25e333e0b2
+      - 449e7e73-013a-4841-b3e7-ec2204c0b8b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:27 GMT
+      - Fri, 10 Nov 2023 13:22:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58c78a8c-3baa-452e-a195-878db32106d4
+      - 99024ea0-14bf-4367-b760-e9526e8fdda5
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:32 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e456d77e-030b-4621-b444-07d33c40f103
+      - db54aa26-478a-4d17-a678-f524f06237a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:37 GMT
+      - Fri, 10 Nov 2023 13:22:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16576fbf-a7a9-442e-8f1a-d1e2fdea22f9
+      - a1d8ea3b-632f-42d7-962d-c8fd6adc830e
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:42 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10815711-ace1-49af-a3df-36d2dd87dba8
+      - 5974ea9e-9824-43be-b375-9268bbf42293
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:47 GMT
+      - Fri, 10 Nov 2023 13:22:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bb26a79-4b58-4a52-ba81-e2f9b356241b
+      - 1b6109c1-4275-4c6d-9ded-1056831d3bda
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:52 GMT
+      - Fri, 10 Nov 2023 13:22:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50a9ebea-5cb4-4dc1-9bde-924503b6ff66
+      - d9376831-8893-4245-a810-60cc6286c4b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:12:57 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a1ce0c6-ef01-4f51-b098-c9fc4fb3ed47
+      - 59c967fe-d901-46a1-a062-cf82b8b7d0ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:02 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f1dfb6-9931-4d57-bb45-71b82b25ee42
+      - 17df9ecc-bd8d-4738-a1c8-00e9528df6ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:07 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b84dba3d-4e37-4cf8-bef5-2f6fba967b38
+      - 282265ca-e1ce-4d79-9611-3db48fe0ae6a
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:12 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 157e9b7a-49bf-45e7-b138-7ecd8fe50091
+      - e3435437-deb9-4f68-ba0c-a4ab753f44ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:17 GMT
+      - Fri, 10 Nov 2023 13:23:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 217ed998-3d45-479b-868d-19c09a0afe28
+      - 6dfb5209-d9c9-494b-bd38-f497aa8f828c
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:23 GMT
+      - Fri, 10 Nov 2023 13:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0e54807-5e1d-47eb-bfd0-cfe4e9af7a50
+      - 8a53a217-3f50-4f26-935a-a6be70ac4fd3
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:28 GMT
+      - Fri, 10 Nov 2023 13:23:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cf7ba11-e0b9-4314-867a-35ebbf55a86a
+      - bf6e0978-7599-47d4-8874-27466093af0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:33 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 703032eb-e4ca-4af5-baab-bd8b1e89f605
+      - 7ee2c939-b0a3-42f3-9efd-c953c5510d41
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:38 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da80a045-1e99-46ee-ad66-53862705eb40
+      - cfa14035-583b-4a4b-8c92-7e476947b91c
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:43 GMT
+      - Fri, 10 Nov 2023 13:23:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8c891f1-6486-476e-8862-d77a2e2484c4
+      - bc4e0e44-8ae5-426f-a6a1-1c7d0f684e32
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:48 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0fe9a83-28dc-4d4c-864c-b83105b8c435
+      - c3fd9058-75bf-4603-8c04-e8f868029730
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:53 GMT
+      - Fri, 10 Nov 2023 13:23:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e459fa2f-01c7-44cc-99d7-cbc87968db85
+      - 817f8cdd-8ffc-4bcf-9c79-be2e3537a1fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:13:58 GMT
+      - Fri, 10 Nov 2023 13:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2925e6df-79fb-492b-aa7e-f82f55bcdda0
+      - 9973ddd8-6ca0-4e4a-9092-7c15609376dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:03 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 787c2521-e4a9-4768-94b4-a5fe07adf067
+      - 2625bf36-bdfa-4449-af0a-8900d7875177
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:08 GMT
+      - Fri, 10 Nov 2023 13:24:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89e173e7-8797-4f52-8c07-39b8e1e8f70c
+      - 3f31e0f3-4397-479c-8697-6c37d2ae32ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:13 GMT
+      - Fri, 10 Nov 2023 13:24:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfc01860-a58c-4864-ab70-9273097a409c
+      - 2953f7b8-15b5-4dd2-812e-83a5ce2e43a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:18 GMT
+      - Fri, 10 Nov 2023 13:24:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2816127b-2175-4eac-ad76-24d6df4c5116
+      - cfa65ffb-cf30-4212-af84-967d3fbc25c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:23 GMT
+      - Fri, 10 Nov 2023 13:24:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde80b90-eb18-40a0-ac22-601644198cf0
+      - 133a66dc-30db-4787-a19c-e8a98348c611
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:28 GMT
+      - Fri, 10 Nov 2023 13:24:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15e30ec9-0694-4c79-a864-a0140c094b2c
+      - 9f85e075-e4bf-4463-b0ca-c8d1fc89e16f
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:33 GMT
+      - Fri, 10 Nov 2023 13:24:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ed986ad-b999-4a8d-90df-a16486148043
+      - 1e4c92bf-8d6d-4936-98e5-a686724e97e1
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:38 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c839f702-0872-40a2-8c8f-1b1869eac378
+      - 11059429-9736-4ec4-a061-e9aaf44e677b
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "644"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:43 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0858f0dc-c379-4b87-bf75-938bc53e3e51
+      - a3efa5d7-f057-4762-8deb-8077defff308
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:48 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d905143-38f0-448b-a6a2-a116b90bfb3d
+      - 61b4ef3d-6b3b-493d-bb7f-ff76d00694a0
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "644"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:53 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 229854d7-5273-4e84-990d-c88a1b85316a
+      - 643ca245-b1d3-431f-86f3-74e199d7a09b
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "644"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:14:59 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c68e9b7b-aed4-4749-85f7-e31cee19fa2f
+      - a36f0613-e757-4bf2-bb14-9fe8ab351aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "644"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:04 GMT
+      - Fri, 10 Nov 2023 13:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1503a75-3c1c-45f8-9a5a-5c18a17e65f6
+      - 7f2f748c-7b84-447d-9812-6d1a54b73540
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "644"
+      - "2614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:09 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e4a58b9-fb3e-4000-ac1a-ac1e3e067292
+      - 64687790-cbd5-4fff-85cf-84c31c856cbf
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "644"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:14 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb9280b5-5f3b-4dfc-b79f-d8bc4b4dbb85
+      - 5e90ec57-7ecb-43e1-84a3-7e7066e672a2
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "644"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:19 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf62e5dd-dbbc-490e-8c7b-125a6e9da00e
+      - 2545b9e0-dd9d-4533-bcd9-bbde775cb5e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "642"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:24 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e86e3a06-2a7a-4056-a3fe-56936f825f2d
+      - d97ea0c9-a921-401e-8aee-f857f95fce98
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1450"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:24 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2d55be8-46e0-4713-a1d4-7aed0342ebb2
+      - 21db017f-a865-4672-98f9-a0b335d31730
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "642"
+      - "2614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:24 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf1aa24-577e-43ab-a54e-1bda10e29590
+      - f6259c62-c39f-4ff9-9f35-6273ad9f1755
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "643"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:24 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a65636f-a7ff-4c88-861e-8ae4478731f6
+      - eb3185f0-6871-4f8d-8903-f401cb5db101
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "705"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:25 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56836ecb-1a56-4336-80f0-eaaff2338f82
+      - eaad91c8-32c0-44d9-bc0f-4b53c647f964
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1450"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:25 GMT
+      - Fri, 10 Nov 2023 13:24:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 153f0d52-6062-435f-b0f6-f9cefa0934cb
+      - a12cf907-9efd-4067-ace6-98ebf282c677
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2612"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:25 GMT
+      - Fri, 10 Nov 2023 13:24:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0e0e1cb-9082-431d-a7e0-6170781f4624
+      - 7c6d0900-53b9-4211-a045-cfab1241c8fb
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "642"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:25 GMT
+      - Fri, 10 Nov 2023 13:24:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68686897-8c65-449d-bb99-e3ade7acd0b6
+      - 89444ce5-0e9f-423d-b454-254b16755f46
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:25 GMT
+      - Fri, 10 Nov 2023 13:24:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,304 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74451d76-feef-4cc0-b683-48fee5e08dbe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "705"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0e5bef1-cc99-4fba-a859-eb2e8dfad921
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1450"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9c1c13bb-5e10-4bd0-a7c3-2b046411b66d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2612"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62ac2376-73fb-406f-b03f-d12d94b11692
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19a61435-0d74-42a3-bfc2-d7de4cc87721
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "643"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ce1fb3d7-583b-4cc9-a9f4-8142c9f2fe6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cfdc14d8-b850-4ce9-83e2-ec39e4c878a9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "643"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55948613-1cc6-4a04-ba30-6d1910a9300b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d7ab1e6-500f-4963-95e8-1e70a105b575
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "643"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:15:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be874201-605f-41fe-ba96-eeeacc0c5f30
+      - 1ec08c7d-9b41-4003-8a71-0cd5f2f67a55
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289052Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990463Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:27 GMT
+      - Fri, 10 Nov 2023 13:24:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fe9739b-4467-4ef7-a674-58262a807986
+      - 50a98322-889f-4573-99cd-720da322289c
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:27 GMT
+      - Fri, 10 Nov 2023 13:24:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 439d6162-d1d5-412c-8c48-40967cafcbe6
+      - 63f1dc64-bdc1-4255-9edd-ae1dc3df2044
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:32 GMT
+      - Fri, 10 Nov 2023 13:24:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbca22f8-a4df-4b61-a36a-7c4bf95e9d91
+      - 1cfd0bf1-dfa4-43d9-996d-2c8299a674a6
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:37 GMT
+      - Fri, 10 Nov 2023 13:24:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13294aa8-5fb4-4cf5-86a4-3ffff036b52d
+      - d095606f-a019-4fe4-87ee-8b1a9aca15af
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:42 GMT
+      - Fri, 10 Nov 2023 13:25:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfd0b9b1-3dbb-4158-881a-1e8f4f23ce69
+      - baa0f599-bd90-46de-a1b9-c9a424ff58c6
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:47 GMT
+      - Fri, 10 Nov 2023 13:25:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d44c0b4-4bc8-402d-9ffc-7322e7d448d8
+      - 37848b03-1d29-4718-a85c-fe8b9345368d
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:52 GMT
+      - Fri, 10 Nov 2023 13:25:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d893046d-0500-46bf-8eeb-498c5456e87c
+      - 8e4d0db1-2433-46d7-87ab-1544fcc5fc2a
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:15:57 GMT
+      - Fri, 10 Nov 2023 13:25:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f996c68-81f4-4970-9bfb-d695d8631051
+      - 06da0964-bac1-41f9-897f-c03503045143
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:02 GMT
+      - Fri, 10 Nov 2023 13:25:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4085152e-eec9-4502-b124-8644ec0d07b2
+      - 32e29da6-5e95-42e2-a8a4-793858bb92ef
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:07 GMT
+      - Fri, 10 Nov 2023 13:25:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea61e228-1096-49c7-8017-496ae8e76637
+      - cdc59d0a-75f2-4a5d-b9b3-d191bb3ddeca
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1453"
+      - "2614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:07 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89f3bb34-7c6d-4886-8684-54f00cca7bdf
+      - 42aefa65-f13b-4f76-993d-f778885aa358
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2612"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:07 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de8b989-414f-4cf1-9043-e277e7b223f5
+      - 72671969-17ff-424f-9a96-6aa178faa965
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "670"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c52c7b-8e3e-4f2e-9d97-ef0eefa4a198
+      - 14b6eddb-38ad-4dfb-a5e5-0aa22b80f37f
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f16bd196-c801-42cc-b08b-fec5d2509260
+      - 00748af5-1fee-4b1b-8389-6760692bcddc
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b4eec5f-9b18-427d-a3f3-73ba5191b0e6
+      - 610a034a-d367-419c-80b8-faab0aa43bd2
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "642"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f585e8f-723d-46f7-bd29-e232ac6d48e9
+      - b1259d7b-b7e7-4c4b-9192-24d2e5c72eab
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "642"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad34fae9-6173-43d6-a2a5-36d79dd8efa5
+      - f8a8c4a1-6363-4bdd-bf1e-828418635a0a
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,19 +3188,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c4cb021-8ca3-4d3a-aa8e-3e3357bd60e7
+      - 3081e3d1-1350-4732-98e2-f4fa9eeb4603
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 547ba5b2-4626-484e-b6d3-95a92c7f1c7f
+      - 7e70a434-64bf-4952-8f02-cc3772364031
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae3f7d0b-8e22-490b-b3d5-b5eb40414423
+      - 81f685bf-ff6c-4c54-bd88-31803c2b8ddb
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9c820f1-724a-473b-96e9-423e2ed895ef
+      - a81e770e-d480-45e3-9f1d-9e4e105cd2c3
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "672"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:08 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd02c5fb-2b83-4f92-adc1-051ab02ffc4a
+      - 92d4e150-397e-4223-8fc6-386361cb12ad
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,19 +3353,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "705"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66c442dd-063a-4392-bfb3-baedd6179376
+      - bfc2a708-dafc-44ca-9c0a-0df73c47523e
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +3386,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1453"
+      - "2614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6242dc7b-2dba-41e5-85ff-87ab65434630
+      - 9501fd51-3f08-4f20-837d-dc66e6a62390
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2612"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03963ea5-2223-49e1-a4e9-866894200e2f
+      - b08ef583-82ea-4990-8d75-37f734d1759f
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,19 +3452,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4503187e-d10d-4dff-9007-264cd9d49984
+      - 5ecb58ed-313f-433c-b42a-f6d82b1661f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +3485,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 924d5d75-ff6d-4717-8cc8-baa619507ae1
+      - 2e054b7d-7a11-4403-9411-34cddd835840
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,19 +3518,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ff13cbc-0610-460b-af9d-7da60dc04c60
+      - 1019d140-2ea1-49d2-96e8-9fff74a25c84
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,19 +3551,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9638393d-4cba-48c3-8b34-567f86b260af
+      - 3f1c5b41-99f6-4e78-aede-6451f3aba6e5
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,19 +3584,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df626982-ec51-498d-8c70-bf261c7e20ea
+      - 286167db-6db2-45c0-a378-8c14f497de11
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,19 +3617,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f111ac8-fca9-4b79-b0fd-7be3bc2e5bf0
+      - 076f2dfe-8b44-4afc-a8f3-2cc22fdbdfe9
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,19 +3650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1d638eb-6d88-4df1-9a3c-7f07b5a42430
+      - 6eb2c6c8-cbee-4bd8-aa6d-7c33fa90a7ee
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d93b058b-75ec-44cc-bd8c-2693b2c6cee6
+      - 7a8ce601-7356-43c3-af91-7f7c06e7166c
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,19 +3716,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0429335-7d79-4e3e-a489-791eb0e9cce7
+      - e5b728cd-d1be-42f2-b171-7a4da55d4fc0
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,19 +3749,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "672"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7218f0f7-81da-4b12-b89b-448c79c1da2f
+      - dbd28597-33d1-4fd7-9498-3cbc28133c9d
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,19 +3782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:09 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5380dee7-ceb3-4770-b4e6-c7e48d2482a9
+      - 769435cd-7404-4b91-aa90-6afe0048d1c5
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,52 +3815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Nov 2023 09:16:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cfb9e0dd-198e-4824-9783-ffa078756698
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632564921Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388488Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:10 GMT
+      - Fri, 10 Nov 2023 13:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b0bd110-fb9b-4661-9f22-a4482865d3f9
+      - eab6c9d8-43fe-4913-997d-03e18d73e5b9
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:10 GMT
+      - Fri, 10 Nov 2023 13:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d123e3ea-1590-47a3-a4a7-5ee9276f60d3
+      - 9f7c13c2-96f3-4345-9429-4e57039e7ba3
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +3881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:15 GMT
+      - Fri, 10 Nov 2023 13:25:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 600cfece-78fe-4e35-8d1f-04190bb5fc05
+      - e85e20e5-b4bc-4ea6-8196-aa8591e3f1e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,19 +3914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:20 GMT
+      - Fri, 10 Nov 2023 13:25:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f56182-c712-41f0-bcad-92cb212807c6
+      - 2040726a-0b69-4b03-afd4-1024b6e645b2
     status: 200 OK
     code: 200
     duration: ""
@@ -4277,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:25 GMT
+      - Fri, 10 Nov 2023 13:25:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f30ed984-fa32-4302-9a2b-f86a54a2b94b
+      - 11304ab8-2196-4485-a62d-9de678d1132e
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:30 GMT
+      - Fri, 10 Nov 2023 13:25:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e26fed0e-ffe6-48a9-bacf-bf5d2a42ccb1
+      - ac55ff6e-60e5-41e9-b2bf-529625922d95
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,19 +4013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:36 GMT
+      - Fri, 10 Nov 2023 13:25:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84c3eb7e-d940-497a-976b-06bdfcba0446
+      - 1bf9ad8e-d53c-4506-859b-50805ee2c03f
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,19 +4046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:41 GMT
+      - Fri, 10 Nov 2023 13:25:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 760ff767-3a60-447c-b699-0bfcbb08d27c
+      - 764e152b-aca5-4072-b5f1-98d3e612ab0d
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,10 +4079,175 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f6b5d25-3c7b-4ec3-8cd5-51846c12422d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0748662e-377d-4c98-a3fb-8e1db3c70d8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5af051c-7da9-49f9-b996-fa8250e9b67f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7fe021a3-1e2b-4fe7-8df5-bec5e540b1c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bda04819-25be-4a4f-b527-8ec083d44734
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4421,7 +4256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:46 GMT
+      - Fri, 10 Nov 2023 13:26:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57c0563a-bcf2-473b-8223-a7588b69379a
+      - 64d9b17e-2a0e-4766-969f-186af971337b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4442,19 +4277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134371905Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149007Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:46 GMT
+      - Fri, 10 Nov 2023 13:26:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7aafd05-bf85-4f12-a962-d620768e4419
+      - 18458e60-bfc4-4450-8904-5c6b3ba2721a
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,19 +4310,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134372Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:46 GMT
+      - Fri, 10 Nov 2023 13:26:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4497,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06522336-fd0b-41e9-9d25-bbda57a5aaad
+      - 4eec4cd9-d9de-4eae-92aa-5ea9cc640219
     status: 200 OK
     code: 200
     duration: ""
@@ -4508,19 +4343,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134372Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1456"
+      - "1501"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:51 GMT
+      - Fri, 10 Nov 2023 13:26:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd90af82-cd05-45fb-a4e8-cd298f47925c
+      - 89cd43bd-8263-4dde-a324-b77261b4f0e0
     status: 200 OK
     code: 200
     duration: ""
@@ -4541,10 +4376,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4553,7 +4388,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:56 GMT
+      - Fri, 10 Nov 2023 13:26:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4563,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b337557-4cea-4dce-bca8-83056ab95c1b
+      - 7671821d-aec9-4b2b-bd6c-611c4136d554
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4574,10 +4409,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4586,7 +4421,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:56 GMT
+      - Fri, 10 Nov 2023 13:26:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4596,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a835a41a-0304-46f6-bce1-d487241d4841
+      - ff9a8876-330a-4fea-ac20-200bd4fac2e6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4607,19 +4442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Nov 2023 09:16:56 GMT
+      - Fri, 10 Nov 2023 13:26:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +4464,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a59ccaa6-bae0-437a-995b-a6b186a742e4
+      - 8d478f9e-451b-4948-a3e3-b87d94587e7b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33fbeede-bfc9-4dd0-afd0-edae4be79675
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b73b999b-7666-45ab-8912-4e949b65dfbb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 262c984d-dcfd-4bb8-8dea-c1a56e8748fc
+      - f4cb66dc-3f09-4602-9793-f271cadeea4b
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48dc0c9f-226a-4d63-8e84-40830ee37133
+      - dea8b09c-1d4b-4e69-911e-f9a2ba000437
     status: 200 OK
     code: 200
     duration: ""
@@ -98,7 +98,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -108,7 +108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e2a1f0-2626-4854-bbc5-fdb2072e20bc
+      - a5640369-388d-4a07-8985-82cb400b8fea
     status: 200 OK
     code: 200
     duration: ""
@@ -135,7 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -145,7 +145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73ba9f7f-a647-419b-8a96-dbbf15ad4b05
+      - e20ec089-7a94-4237-988e-9f871c36ebb0
     status: 200 OK
     code: 200
     duration: ""
@@ -161,16 +161,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -180,7 +180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84efed90-690c-4304-9847-5379714e50fe
+      - 0c728e11-3a1f-4a16-b848-b3a55d67bc06
     status: 200 OK
     code: 200
     duration: ""
@@ -191,19 +191,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -213,12 +213,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c44850d-1335-4a57-823f-a5e070988197
+      - f3712dc3-1c38-4d16-be59-ee3970bd58e0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c"}'
     form: {}
     headers:
       Content-Type:
@@ -229,16 +229,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081695626Z","created_at":"2023-11-07T16:20:01.081695626Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.092822070Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506226949Z","created_at":"2023-11-10T13:23:01.506226949Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:01.517085294Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -248,7 +248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 599ccced-c5bf-4043-972a-ba653a6a12b2
+      - 874b386c-ad99-4834-994f-a044b28ea8e0
     status: 200 OK
     code: 200
     duration: ""
@@ -259,19 +259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.092822Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:01.517085Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -281,7 +281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da559be3-3e01-4b1f-b4dc-9754777c911f
+      - d4228167-39da-48fb-b56f-6b155a7e35be
     status: 200 OK
     code: 200
     duration: ""
@@ -292,19 +292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -314,7 +314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0a7d31f-e51b-43bc-99dd-8fb5c29a43dc
+      - 648d5c4d-8f55-408e-ab53-85a910f00d36
     status: 200 OK
     code: 200
     duration: ""
@@ -325,19 +325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -347,7 +347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b1d9a5-30e4-467f-b49e-11ed40867b2d
+      - 1812c224-fcd7-48cd-8e88-64a4bd8f0a64
     status: 200 OK
     code: 200
     duration: ""
@@ -358,19 +358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -380,7 +380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1adcac9-cdee-450a-8300-abed9ab82b14
+      - c517e969-9208-46b6-ad01-d7b5817f7a33
     status: 200 OK
     code: 200
     duration: ""
@@ -391,19 +391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -413,7 +413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 017cbd31-6fa8-4ba3-978b-ad496fd40119
+      - 53f1bed0-3a37-4e2f-ba5a-dcf22d74af13
     status: 200 OK
     code: 200
     duration: ""
@@ -424,19 +424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -446,7 +446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03bb531a-1f09-416a-b18c-8659857182ee
+      - fdb4221a-1ff3-4e67-823e-a6aebce17b41
     status: 200 OK
     code: 200
     duration: ""
@@ -457,19 +457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -479,7 +479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f46107b-272e-4097-9891-0a8f53f1bca2
+      - 6af8ff35-05f0-40f9-89c9-fecec5eeee8e
     status: 200 OK
     code: 200
     duration: ""
@@ -490,19 +490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -512,7 +512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d137a0b-c5d1-4c61-8066-72100741805c
+      - 691a5550-b93c-4a02-8139-96591bde8cbe
     status: 200 OK
     code: 200
     duration: ""
@@ -523,19 +523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -545,7 +545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c1e0299-4c98-48cd-9ff9-b3cf511a7cb3
+      - a0db439c-63c4-42e4-a9c4-1bcdb3b0dfa9
     status: 200 OK
     code: 200
     duration: ""
@@ -556,19 +556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -578,7 +578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71c96ec6-56c8-4dac-bf9b-37bf05c60656
+      - a1d23dee-8aea-4131-b194-bd5166fa5997
     status: 200 OK
     code: 200
     duration: ""
@@ -589,19 +589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -611,7 +611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17a19a7-c93c-4dfc-a4c5-8a3abdea92c4
+      - 293fe177-7ce4-4675-8566-eb3364d9cfd8
     status: 200 OK
     code: 200
     duration: ""
@@ -638,7 +638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -648,7 +648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a836999-5282-421c-b791-3c80a924e94e
+      - 27f13a0c-8896-4631-ba04-31a79fd06681
     status: 200 OK
     code: 200
     duration: ""
@@ -659,19 +659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -681,7 +681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88de29ad-7328-4c08-9695-7c9ce1311dbe
+      - 81c4b99c-85dc-4bcb-aee5-609bad980c1c
     status: 200 OK
     code: 200
     duration: ""
@@ -694,19 +694,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.253288979Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:08.439822544Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1461"
+      - "1506"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -716,7 +716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df971082-3bd9-4ba5-bfcf-4f10d9d291fc
+      - 04c80eaa-d998-46db-8fc5-880c6c17ea4f
     status: 200 OK
     code: 200
     duration: ""
@@ -727,19 +727,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.253289Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:08.439823Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -749,7 +749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef1e83d-7e89-4125-8e41-e44464560035
+      - 56709b88-3a0d-4208-947c-f8042179de67
     status: 200 OK
     code: 200
     duration: ""
@@ -760,19 +760,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:13 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -782,7 +782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9168901f-b7fe-46ce-a5be-4c009f35325d
+      - 9802ad7a-fa95-4550-a5e7-a292ff45b950
     status: 200 OK
     code: 200
     duration: ""
@@ -793,19 +793,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:13 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -815,7 +815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d785cb5f-02d5-4772-8d35-841e23b3014d
+      - cc8047a7-93f0-4bc2-b38b-d9708d7f05fe
     status: 200 OK
     code: 200
     duration: ""
@@ -826,19 +826,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:13 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -848,7 +848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41b25aac-5d5b-47e2-ac4e-a291a89fdabd
+      - 1b5e01f5-e4ca-4773-a1ec-bb5ad3d4772f
     status: 200 OK
     code: 200
     duration: ""
@@ -859,19 +859,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:14 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -881,7 +881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6733f91-e1be-4002-84c7-bffcf891e680
+      - 8a4a5b39-1c6a-4a1f-aba3-c7bd5af94c68
     status: 200 OK
     code: 200
     duration: ""
@@ -892,19 +892,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:14 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -914,7 +914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1cf5514-886f-466e-a154-87317361932c
+      - 2723a334-269e-461a-ae59-bafb50a5e1ac
     status: 200 OK
     code: 200
     duration: ""
@@ -925,19 +925,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:14 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -947,7 +947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 454f1697-43b0-40ab-9488-eecfee77dc91
+      - 6a9f65f2-6a2a-470c-b499-fa2b6411f7f5
     status: 200 OK
     code: 200
     duration: ""
@@ -958,19 +958,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:14 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -980,7 +980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9707fb0-fd8c-49ab-a7f7-0cfed886a96a
+      - 2fb44cc6-084d-4b35-84d4-c222b6ab684c
     status: 200 OK
     code: 200
     duration: ""
@@ -991,19 +991,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1013,7 +1013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92b8f13f-4424-40a3-9229-9fcfe0e8134d
+      - 5d6f4fc0-309b-4783-a377-360596e91e1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1024,19 +1024,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1046,7 +1046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 657bf7bc-7a2c-4ae5-8787-28c9a301acf4
+      - 52fe7f39-edbd-4476-b9ae-600a8def122f
     status: 200 OK
     code: 200
     duration: ""
@@ -1057,19 +1057,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1079,7 +1079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a2485e8-02fb-47c8-b4dd-f1c7533fbe1e
+      - e58db1e9-bc65-4111-9070-c2949db4b822
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,7 +1106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:23:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1116,7 +1116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77c144d5-643a-4979-a390-8e605aa3719f
+      - 8088e7c2-a5f1-4430-a75b-1b0b06c2cbc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1127,19 +1127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:23:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1149,7 +1149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ec19da2-ca13-45bc-99a3-941a0ab58cd2
+      - 5284ed0f-72ca-4f09-af62-3cb987563f64
     status: 200 OK
     code: 200
     duration: ""
@@ -1162,19 +1162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.388844462Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:15.443631381Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1461"
+      - "1506"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:23:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1184,7 +1184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6788d37e-2095-4e8b-bb37-8eccc7d7da9f
+      - 9aeb719a-7c7a-4ff1-9621-a55efcf9348f
     status: 200 OK
     code: 200
     duration: ""
@@ -1195,19 +1195,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.388844Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:15.443631Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:23:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1217,7 +1217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 251c5b1f-e2e4-4324-aa93-c1cc5eaef8af
+      - de8e2717-a85f-4659-a6c3-2dfe7d11c5c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1228,19 +1228,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.690666Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:16.577657Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:21 GMT
+      - Fri, 10 Nov 2023 13:23:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1250,7 +1250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7d64495-f7a5-495d-8bb7-7cbbeeaf7f9a
+      - 38e9c8fd-4dd1-4a37-8230-f806dd4489b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1263,19 +1263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:22.100507845Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:20.610441424Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1462"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:23:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1285,7 +1285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c11d204-1c77-455e-ad07-1beab1b6d8a9
+      - 38431cdb-703f-4579-923d-fcf41de26861
     status: 200 OK
     code: 200
     duration: ""
@@ -1296,19 +1296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:22.100508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:20.610441Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:23:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1318,7 +1318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ac505b7-0f4c-4472-bb97-40e6630fc7b4
+      - bc08c0f4-bcc5-43d7-8c0a-fc8b4e84a2b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1329,19 +1329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:23:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1351,7 +1351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6749c05-7314-4d14-92b3-60ba154ea165
+      - 26f94a26-9215-41b3-a883-52a72c497b00
     status: 200 OK
     code: 200
     duration: ""
@@ -1362,19 +1362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:23:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1384,7 +1384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71615b7-27d7-458f-a687-9f79918430d8
+      - 7c474802-8840-48aa-8bbd-b8f58b264247
     status: 200 OK
     code: 200
     duration: ""
@@ -1395,19 +1395,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:23:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1417,7 +1417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb07995f-09b7-4dc6-8e42-d9378f3006f0
+      - 14ee9928-6b2c-4f84-80cb-22076ab25fe2
     status: 200 OK
     code: 200
     duration: ""
@@ -1428,19 +1428,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1450,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3c9ac74-0f05-4860-abc4-5c36f0d4f4bd
+      - d1c85e5e-310b-4400-b978-df8edb2ac207
     status: 200 OK
     code: 200
     duration: ""
@@ -1461,19 +1461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:27 GMT
+      - Fri, 10 Nov 2023 13:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1483,7 +1483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21100362-c1a6-42ac-ac4a-f963f9bc4bf8
+      - ddce9769-e0ed-4e2e-9fa8-05e4aa142c28
     status: 200 OK
     code: 200
     duration: ""
@@ -1494,19 +1494,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:28 GMT
+      - Fri, 10 Nov 2023 13:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1516,7 +1516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1e96cf1-70e6-4e20-bb2d-2b88e27430b5
+      - 5ab88d72-84f6-4ca0-ae88-565a2db5a4cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1527,19 +1527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:28 GMT
+      - Fri, 10 Nov 2023 13:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1549,7 +1549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 579b4d0f-20a0-4d66-848b-8fb7cf0c4557
+      - 6b9f3350-99ed-4b24-a720-114bb352367d
     status: 200 OK
     code: 200
     duration: ""
@@ -1560,19 +1560,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:28 GMT
+      - Fri, 10 Nov 2023 13:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1582,7 +1582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88cbe7e5-913e-4269-86a1-94043c892292
+      - 6fafc23b-08fb-4455-ad80-054b9f2dd302
     status: 200 OK
     code: 200
     duration: ""
@@ -1593,19 +1593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:28 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1615,7 +1615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f6e3ed3-8c2e-4f74-830c-87b93276ab75
+      - bc65340d-1a93-4fc0-9bd3-3ce217f1f564
     status: 200 OK
     code: 200
     duration: ""
@@ -1626,19 +1626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:31 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1648,7 +1648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61592b6a-bc71-4cd0-92fd-7ee5373c17f2
+      - ee3d0464-55b0-4b4c-8067-2dcbe91f80a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1659,19 +1659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:32 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1681,7 +1681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 959b45cc-df6f-4f6f-8253-5fe935fa7423
+      - 33cff578-f4c6-40ab-90db-a6b0df8ba5c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1694,19 +1694,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:32.345322806Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665320906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:32 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1716,7 +1716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e652cf10-9c9e-4839-9b38-625f8ffd7b01
+      - d22dff70-238f-47ef-8bbb-5d1a9e1ce045
     status: 200 OK
     code: 200
     duration: ""
@@ -1727,19 +1727,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:32.345323Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665321Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1460"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:32 GMT
+      - Fri, 10 Nov 2023 13:23:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1749,7 +1749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c457f15-36d2-466d-9752-305ac7357a5e
+      - 31f7a8c8-95e4-4165-bdf9-fc265bcd0687
     status: 200 OK
     code: 200
     duration: ""
@@ -1760,19 +1760,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665321Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:37 GMT
+      - Fri, 10 Nov 2023 13:23:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1782,7 +1782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62a912b6-33b6-4936-a093-2626674001f7
+      - b82a2cf2-356b-43e8-af06-49ebe20ccabb
     status: 200 OK
     code: 200
     duration: ""
@@ -1793,19 +1793,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:37 GMT
+      - Fri, 10 Nov 2023 13:23:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1815,7 +1815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dcaaa54-e41e-46c2-a8ba-917de3445f77
+      - 1c1f4811-94f5-4819-8a05-110c226308bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1826,19 +1826,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2628"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:37 GMT
+      - Fri, 10 Nov 2023 13:23:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1848,7 +1848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fbba46f-923a-4cca-adf9-b3ea9e252769
+      - 8849fb27-64b7-48e5-bb0c-ce182ba060b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1859,19 +1859,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1465"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:37 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1881,7 +1881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f69828d6-eda5-4f7a-8e53-088cf5dbfda4
+      - 0e33e5c5-96b4-4980-b0bb-3ed4f80115a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,19 +1892,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "699"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1914,7 +1914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15ce3a3a-3bc2-430b-870c-9fb8ec9eabbc
+      - 4d7a4f7f-c061-41e6-81c9-207ced4b1852
     status: 200 OK
     code: 200
     duration: ""
@@ -1925,19 +1925,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1465"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1947,7 +1947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fc9e65a-4f36-4052-997f-3827d7e830ca
+      - 57eab7cb-b907-494b-a2a5-5286117fbd1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1958,19 +1958,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2628"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1980,7 +1980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd466476-e7a4-42b6-a134-8536859fc306
+      - d9f3dc86-13a5-4e5c-b3eb-7d300fd21c1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1991,19 +1991,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "699"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2013,7 +2013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0837111-f7e5-4e38-8f0c-dced219884dc
+      - d0d75865-01c8-444b-8e1e-82eda74d548c
     status: 200 OK
     code: 200
     duration: ""
@@ -2024,19 +2024,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1465"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2046,7 +2046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52d1a55d-82d1-4644-bf7a-6a69748a7e26
+      - a0aa9a11-7fd1-49e4-ba95-8469e3761c73
     status: 200 OK
     code: 200
     duration: ""
@@ -2057,19 +2057,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2628"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2079,7 +2079,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a0c8271-c523-4655-9d3f-887920fc37dc
+      - a1680143-9e01-4f6b-8b5f-27d1fdf4300b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f102b75e-c592-4743-85f8-4b7b815554c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2106,7 +2139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:39 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e4ef00b-4dee-42e0-a6e9-be09bba696ce
+      - 30885abf-ffa4-46c7-b4e5-0595525c04f1
     status: 200 OK
     code: 200
     duration: ""
@@ -2127,19 +2160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:39 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e9b96b-43d9-4bb1-a6ac-728a12e8f191
+      - 40411ce4-f81a-4467-a9be-cc4071b07daa
     status: 200 OK
     code: 200
     duration: ""
@@ -2162,19 +2195,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:39.251402866Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:39.950990034Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1466"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:39 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2184,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66cdf7f7-642a-4430-9a1b-1c7f802dad78
+      - 4ea4e6ed-052d-4a1e-bb52-ca6826140de0
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,19 +2228,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:39.251403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:39.950990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:39 GMT
+      - Fri, 10 Nov 2023 13:23:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2217,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a04531-756a-4a1c-a86d-adc8f6f6ab02
+      - 472c29fc-027c-4a84-b391-7de081fcde0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,19 +2261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2250,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33d0d410-50f5-4690-84b4-1cdd890cbbaa
+      - 0c6ccf86-4db9-48d8-9f14-bc365d048cd2
     status: 200 OK
     code: 200
     duration: ""
@@ -2261,19 +2294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e47576f-31b5-460e-add2-1ae33f6fc478
+      - 2ac1e50c-c12d-4673-9b18-e5c0328f38db
     status: 200 OK
     code: 200
     duration: ""
@@ -2294,19 +2327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 196b5d15-0c10-424d-b5ed-0fd551a1725d
+      - 614efcdf-9521-4203-b84e-f35e90be9612
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,19 +2360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6688c6e9-3dfe-4c6e-b920-9d6ae7144677
+      - 313beb5a-134a-4eef-89d1-b1de0e1251c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,19 +2393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3e259be-fc63-4738-959c-98adc675f6ac
+      - 30d32833-26a1-48d0-b08c-5dc20bab7416
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,19 +2426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1d19522-f885-46d4-aa9c-47f5640c60a2
+      - 2bbb73b7-5e07-4f88-9d77-f3a7bf8db7b8
     status: 200 OK
     code: 200
     duration: ""
@@ -2426,19 +2459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:45 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a6de6dd-0bb0-4bc6-ae80-d7c501429a38
+      - 6ddaf255-c9d0-4b14-9d90-b3bf016220fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2459,19 +2492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:45 GMT
+      - Fri, 10 Nov 2023 13:23:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfa4bc92-00c7-4341-b569-59c008e46fef
+      - 35f2013e-7d85-4b7c-9edf-ad09d67f2156
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,19 +2525,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:45 GMT
+      - Fri, 10 Nov 2023 13:23:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adc2e104-261f-4137-82a9-f737d518de69
+      - 59e84523-5f54-4f16-85a6-417f16e40a17
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,19 +2558,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:45 GMT
+      - Fri, 10 Nov 2023 13:23:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 707d45a5-66c5-42e9-916d-610ced405fb7
+      - 4e09b2d1-9960-4700-b134-6248e596de38
     status: 200 OK
     code: 200
     duration: ""
@@ -2574,7 +2607,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:46 GMT
+      - Fri, 10 Nov 2023 13:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2584,7 +2617,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 685b9bea-6660-4c07-96ff-c924747a3043
+      - d46c564b-badc-461f-a7da-055fba1a231c
     status: 200 OK
     code: 200
     duration: ""
@@ -2597,19 +2630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:46.069336829Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:47.229804131Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1462"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:46 GMT
+      - Fri, 10 Nov 2023 13:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2619,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03e3dc84-4547-4901-99f9-77b924143038
+      - 4700c99f-b82a-4915-a9a6-2691df050491
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,19 +2663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:46.069337Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:47.229804Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:46 GMT
+      - Fri, 10 Nov 2023 13:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e690d36-3d16-4527-80f8-b996851e6e66
+      - 937d66eb-c609-46e9-ac07-65a5e352dd67
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,19 +2696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78e45673-5f9e-47ff-839c-0d1c590f6571
+      - 68087ff0-7fc0-411f-84d9-e864c56abb3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd4e3d85-91f5-46eb-9890-035f89c389bb
+      - f1be73df-cb27-4572-ab9b-654d0f6d4a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,19 +2762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f35c5d62-e8b4-4dd6-9773-4bc1b26e59aa
+      - 6bab398a-b06c-4556-89ad-2c35abc60499
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,19 +2795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2784,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ff4f673-04a2-4295-b967-84b003687279
+      - 38793228-229d-4913-a3e5-bd7b767ba520
     status: 200 OK
     code: 200
     duration: ""
@@ -2795,19 +2828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "699"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbe083d8-83ed-47a0-a3d3-6f4ce5ec1aac
+      - 869c8133-57ea-4969-993a-370b972767c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,19 +2861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eef9c57-7c5b-41d9-88ef-3b3048470207
+      - 78324622-bb37-43ba-8980-3d1eb616a73d
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,19 +2894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:51 GMT
+      - Fri, 10 Nov 2023 13:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b190735-caca-43f6-8a3e-3fe1bd2a8917
+      - f2ffc8fa-e19f-4e75-8a47-3665422fe272
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607035Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313101Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1462"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:52 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61c72e17-cce1-4eb2-924e-db78c7d6a0a4
+      - c1681a94-7923-4b4e-9a7c-1de80ab4bedf
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,19 +2960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:52 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +2982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 240f9889-d7d7-41d4-92ba-dfe347855517
+      - bf10dd22-c4eb-4312-8cc5-5ef346d41ab9
     status: 200 OK
     code: 200
     duration: ""
@@ -2960,19 +2993,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1459"
+      - "1504"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:57 GMT
+      - Fri, 10 Nov 2023 13:23:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2982,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3df91742-5a06-40b7-8954-344dde481c16
+      - b9faeb5d-40dd-4748-ae48-771613e626b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2993,10 +3026,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"32d07d36-3491-4dfa-9709-b92432ab2e79","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1504"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19c84935-eb81-497d-abb0-2527fa63c86d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"530d6423-2bae-4683-978d-8967007944fc","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3005,7 +3071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:02 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3015,7 +3081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10fe92df-da0c-4552-be4f-50e828534caf
+      - 9cafab20-7fb7-4ec6-8d66-4fac363fc5f9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3026,10 +3092,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3038,7 +3104,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:02 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3048,7 +3114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74d76f4b-3df3-48fe-865b-5fd9963339d9
+      - f7261c0d-860f-489d-a358-ca6b5c54f21c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3059,19 +3125,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"32d07d36-3491-4dfa-9709-b92432ab2e79","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:02 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3081,7 +3147,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 658cecdc-f8dc-4c9a-b81f-f0be8e6eed2e
+      - be425169-c068-4e7c-87f0-523d012f3d28
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"530d6423-2bae-4683-978d-8967007944fc","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95ecfeff-fe67-4660-be57-0a6db16dc8a0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5406efca-2ded-464b-88fe-65e4d247949b
+      - bf963749-9261-4a77-aabf-d464b8de8ce2
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "699"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:04 GMT
+      - Fri, 10 Nov 2023 13:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afe9bd08-3ec7-470b-a578-8b6ff9ce1299
+      - ea2d3e0e-dc6a-4c06-b2df-19f1d65cdba2
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "699"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:04 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 979b12f0-11a1-4bc2-a41a-1c6b3d4a04b7
+      - e6548859-3b89-4ccb-a814-2046284d3718
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"fc79e33c-2733-41ba-ab51-205753408640"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027480893Z","created_at":"2023-11-07T16:21:05.027480893Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:05.043551677Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452737578Z","created_at":"2023-11-10T13:16:58.452737578Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.470605368Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1480"
+      - "1525"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:05 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e74074dc-e890-4261-8789-c747f8a9247d
+      - 9ea28460-5b7c-423e-a134-5a67738f2ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:05.043552Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.470605Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:05 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28b00bd7-3d97-48c5-9321-212bd7f9a3fd
+      - ae7e876e-60c7-41fb-876c-067dfb1cf3ad
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d68c3e6-a35c-4430-9760-1a92802fce45
+      - d4ccef75-5cac-45ac-bd7b-9608e8e8b6b1
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4762701-415c-493e-8ccf-e4589244f0f7
+      - ecd5d316-ab38-4a43-8e67-043146ed6bfa
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596eeba8-4912-4872-937c-bf6cb07fdc76
+      - 85a54af3-e432-4803-9ace-6c359f09fb24
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0237d3e-654a-4a25-a1e8-3ad284fc1694
+      - e2d9b8ce-1b46-4786-b13d-15af850b927b
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "699"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbc25809-a990-4c54-a518-40ff8a956a77
+      - 45592fd3-b43a-41a6-9eeb-394f17e05c4d
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9963eace-5f96-407b-9e56-59cce5cad0f9
+      - cf2930ac-0112-4b41-a4f7-4874ffb1d22b
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54d538bc-9555-49c8-9085-975c13244225
+      - aa530d69-9426-4b38-ada2-fda9eddd1bf6
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "699"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 719617ce-8926-4885-a397-94d90040e16f
+      - 5672194b-a60b-4a77-835f-620ffaab755e
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f134fa1b-6de2-4da0-aecd-0a210b3db7df
+      - 5ed4c07c-4a54-4493-b455-bc38aaca768c
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e9e9601-6c4b-4865-85eb-31577f671f6c
+      - 3ee01d90-87f4-4384-932a-8dd39019bc1a
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:12.192466805Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.261446827Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1475"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:12 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ae8f578-2264-4761-9c07-6f919c2a61a8
+      - 093695d3-af6d-4e2f-a1da-581dc608d87b
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:12.192467Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.261447Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1472"
+      - "1517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:12 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33627d3f-3ac3-4a3b-af4d-f90f0632f21d
+      - 54f91a08-21bd-4885-9dd7-d45b6cb910a3
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1477"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:17 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 595e7251-3b16-4591-8522-6777110c5c14
+      - fc099447-7b77-4924-ad90-ca33f413e3c4
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1477"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:17 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 154f026f-d9a6-4dc5-8723-d880e734028f
+      - f6ce6c61-dfe5-453e-ac63-88b501f30c7b
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:17 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5064d253-d4b6-4232-88f9-a10b23d27c96
+      - 61755195-4035-4472-923e-b98f5facdb55
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1477"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:17 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ab32be8-080e-40e6-a74a-abf1501e1fcf
+      - 55b2a88d-a5b6-4601-9b2f-c09471ac3908
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "699"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:17 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5c7c0c7-b6ef-498a-b8d8-80a7bcf39f09
+      - 730d1a6c-b4fa-42f2-9774-95127c8c712c
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1477"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e352f51-ec05-4902-bcd3-95759630ff85
+      - c211d7ee-0be9-4935-a814-cfc61373c4b4
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6989c342-8239-4e4e-b9b2-43c97f9bd62d
+      - c2a42eb5-0f03-4777-98c1-99d9473d6e5e
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789178Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863077563Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1475"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1251e4e-d0bc-4e1c-91bf-de63a52b4159
+      - fe042439-f5fb-4800-b616-9f57f8b6d459
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863078Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1472"
+      - "1517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:17:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64258434-f5ad-4162-a430-4e67a28c4dec
+      - 7ac2c4eb-af87-455a-8f36-2ef66273e052
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863078Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1472"
+      - "1517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:23 GMT
+      - Fri, 10 Nov 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1714d80e-435e-4b07-bcd2-e8ece98e9f26
+      - 3f7046d6-f9db-4d5f-93cc-27e47532ad99
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54ee731c-48ea-4c33-9246-501936322cf8","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:28 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1a643f7-651e-40b5-8fdf-998bc0427c61
+      - 8077108b-ef26-4f5b-90db-b2f5f11a488c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fc79e33c-2733-41ba-ab51-205753408640","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3c161a30-867c-4716-836a-fa5bc167c926","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:29 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc516d75-563e-4777-a2bb-d1926c154eb8
+      - 4988f9b7-494f-4fc3-b281-f8af66f37ebe
     status: 404 Not Found
     code: 404
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3c161a30-867c-4716-836a-fa5bc167c926","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:29 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39d87a5f-36d0-439c-aa2e-6cba8cd8e6a6
+      - 2ad1a4dc-f755-4461-9610-abab411f307e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54ee731c-48ea-4c33-9246-501936322cf8","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a16e260-661e-4e0d-9566-ce2ada9151cc
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f5bdfd6-77df-457a-82ee-cfbb79084782
+      - c63ba6c6-5948-4995-8d3f-810c6703c4e4
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92713f32-3d97-42ee-897e-a3aaeb65f0e8
+      - 4f92e699-690e-46dd-8201-858065c84f14
     status: 200 OK
     code: 200
     duration: ""
@@ -87,16 +87,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "696"
+      - "712"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -106,7 +106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07f55291-e785-4ee2-856c-055da2b4a602
+      - 278a3af8-96ed-425b-aa91-dfa4eb0528dd
     status: 200 OK
     code: 200
     duration: ""
@@ -117,19 +117,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "696"
+      - "712"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e3735ee-001c-44f6-9020-ba04cf7a4011
+      - 1f2f3e21-1929-4c00-b39d-f457a84c6379
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e"}'
     form: {}
     headers:
       Content-Type:
@@ -155,16 +155,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079101Z","created_at":"2023-11-07T16:24:26.509079101Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:26.520514787Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162030Z","created_at":"2023-11-10T13:16:58.935162030Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.988451657Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 270b89ec-5963-4336-926e-597304c3ce01
+      - 1141be87-c7d1-4122-9c67-dcb310ea7b92
     status: 200 OK
     code: 200
     duration: ""
@@ -185,19 +185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:26.520515Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.988452Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ac11dd9-92bd-463e-ad0d-ae64aeaf73e5
+      - 73f7897f-c1a9-4cbc-96da-7076389921c2
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08a15768-f141-46b2-bc4a-ad72bf5aeffd
+      - b7e4ab59-6f44-4b53-bcf2-08b5f9c7db87
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f020937-ae2a-4758-88b0-e0730e355341
+      - 7d0b4588-c215-49e3-b869-ecd1711a496d
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2588"
+      - "2590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b49b8af-8358-4ed1-b48b-33498703ddbc
+      - 51d7765e-caeb-4f0c-a780-89189fdf3e60
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8837dc54-93f2-4132-a28d-08a0f502bdb8
+      - 6d5ccb8a-4800-4914-8fa9-260d988cf0ad
     status: 200 OK
     code: 200
     duration: ""
@@ -350,19 +350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "696"
+      - "712"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,7 +372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c07b508a-e6a9-476d-a197-d43cb6124188
+      - 10cc02ac-c5b5-4c2f-b36f-0a9c43e6cd74
     status: 200 OK
     code: 200
     duration: ""
@@ -383,19 +383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b1232a6-dd49-4f62-9820-4d8df9b01ec7
+      - f652153b-cc02-47ad-82b0-533a04dd9595
     status: 200 OK
     code: 200
     duration: ""
@@ -416,19 +416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2588"
+      - "2590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6aa1ef26-eae0-425e-8f83-6d6ace7edb06
+      - f6bb0d9a-72a4-45e2-8a29-3806090f339d
     status: 200 OK
     code: 200
     duration: ""
@@ -449,19 +449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "696"
+      - "712"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de1380a8-5def-4368-9026-71cb9f953b16
+      - 8388cbeb-009c-44a1-8268-89e093f852cd
     status: 200 OK
     code: 200
     duration: ""
@@ -482,19 +482,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 482881e2-f90a-441a-a62e-b606109a61fe
+      - e002350d-0083-4a46-a9ac-c31ecc95e6f8
     status: 200 OK
     code: 200
     duration: ""
@@ -515,19 +515,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2588"
+      - "2590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:32 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0695590-10fa-4a06-8970-238058cde499
+      - 967c5f66-ed0a-4b64-a7ab-af9ac24226cd
     status: 200 OK
     code: 200
     duration: ""
@@ -548,19 +548,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:33 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0d5f459-ab3f-4d94-8c5f-812dbc4a72c5
+      - bf6772cb-861d-4b85-bb0b-928b519b232c
     status: 200 OK
     code: 200
     duration: ""
@@ -583,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:33.410493663Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.550394867Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:33 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b39647b-724d-4968-a6ee-9745526723b9
+      - 4a359c8d-28e6-4db3-9ca0-df30cf2b52ae
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:33.410494Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.550395Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:33 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 120087f6-908e-48b6-b45a-d32c3c234d9b
+      - 7c8c222e-ff9d-4097-902a-f4ff7b6b6415
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:34.520580Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.682501Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:38 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e98ba4da-8a38-4519-ba8d-a649ad58e154
+      - 679ddcfc-6c43-4113-a5d1-7f5893fb0b51
     status: 200 OK
     code: 200
     duration: ""
@@ -684,19 +684,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:38.620967533Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907217Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:38 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -706,7 +706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d24c7fbb-4002-4b08-8b23-753f5e1a5371
+      - 37a8b1e9-3ab3-44f2-909f-13d6e4178f5f
     status: 200 OK
     code: 200
     duration: ""
@@ -717,19 +717,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:38.620968Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1450"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:38 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -739,7 +739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be0e2aa7-8ca3-4467-a2de-b2115dbcce64
+      - 3295de9c-6316-48f5-879d-2103c63b284e
     status: 200 OK
     code: 200
     duration: ""
@@ -750,19 +750,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:43 GMT
+      - Fri, 10 Nov 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -772,7 +772,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b214c77-c04b-4a1b-8a89-7398e899f84f
+      - b7083232-fc70-494d-9b18-662ad5893497
     status: 200 OK
     code: 200
     duration: ""
@@ -783,19 +783,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:43 GMT
+      - Fri, 10 Nov 2023 13:17:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -805,7 +805,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ed6a367-ac94-4d4b-aa29-1325b291239b
+      - 8831c5d4-d0f5-4765-a52f-f72d4243f9be
     status: 200 OK
     code: 200
     duration: ""
@@ -816,19 +816,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2588"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:43 GMT
+      - Fri, 10 Nov 2023 13:17:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -838,7 +838,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3de4a548-3059-488a-82a4-3ea6acc8ffe7
+      - 5eeb6056-66a7-4b96-b927-d31c75f98a00
     status: 200 OK
     code: 200
     duration: ""
@@ -849,19 +849,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:44 GMT
+      - Fri, 10 Nov 2023 13:17:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +871,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1707f314-6ca3-4ca9-8e7c-463e85346f9e
+      - 1e6564ce-f2c8-4d84-8991-4ce270ff90a5
     status: 200 OK
     code: 200
     duration: ""
@@ -882,19 +882,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "696"
+      - "2590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:44 GMT
+      - Fri, 10 Nov 2023 13:17:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83a70de4-82bf-405d-8c40-b268935f73e5
+      - efc233a6-69a8-40ae-af74-2a057e877c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -915,19 +915,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:44 GMT
+      - Fri, 10 Nov 2023 13:17:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 496dc40b-eab2-4b3d-a390-1080389cb73d
+      - ffa8d1c5-6f14-427b-bb7d-0a00a3097c55
     status: 200 OK
     code: 200
     duration: ""
@@ -948,19 +948,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2588"
+      - "712"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:44 GMT
+      - Fri, 10 Nov 2023 13:17:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -970,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 777250b1-698f-4758-bfab-172f0284f919
+      - 3b313a5c-f671-4d82-b8af-0544e8b39408
     status: 200 OK
     code: 200
     duration: ""
@@ -981,19 +981,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1500"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51bf5f71-d6d8-4b3d-a27b-1ba21f393a41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5228289-e7e6-4c2b-b5fc-38d5450d87f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112062619Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1498"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:45 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +1069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f867189e-09ee-4804-80ec-e910e3d8afeb
+      - 45a32447-b460-4cab-a8a4-3fcb2932ebc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1014,19 +1080,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112063Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1450"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:45 GMT
+      - Fri, 10 Nov 2023 13:17:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1036,7 +1102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e785b1-351b-4c83-8309-b58b3ca60f57
+      - 9c8aaece-e30c-42d6-a34c-4754d6c4ead0
     status: 200 OK
     code: 200
     duration: ""
@@ -1047,19 +1113,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112063Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1450"
+      - "1495"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:50 GMT
+      - Fri, 10 Nov 2023 13:17:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4aae3fc-70a7-4b91-a5d7-d69da82ee1ec
+      - 8ea8c89a-c391-43c8-b995-32622b7f73ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,10 +1146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1092,7 +1158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:55 GMT
+      - Fri, 10 Nov 2023 13:17:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1102,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4e71b15-cacb-45de-b569-2dbd23951e7c
+      - 648d3e15-a5e2-411c-932f-e060ea0f79fc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1113,10 +1179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"38d51a1a-233e-48da-9b96-feb735b75055","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1125,7 +1191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:55 GMT
+      - Fri, 10 Nov 2023 13:17:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1135,7 +1201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce506257-a7ca-46e7-8a6a-a13314bf6bbd
+      - c6f56ff4-2bbd-49da-b875-43afdd418d1b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1146,19 +1212,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:55 GMT
+      - Fri, 10 Nov 2023 13:17:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1168,7 +1234,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e25a4be-ed6b-4631-b6dc-6a229ba67ff9
+      - 332839a8-92aa-4b30-a9af-651f8cfb05f5
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - effa8cfc-a118-4afb-8a56-231e9e7f8dba
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e772d889-6982-4b3e-a4d5-26a5b884b08a
+      - b893b688-6359-455b-b22d-9cfe73c8c11c
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842341Z","created_at":"2023-11-07T16:19:59.742842341Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753797713Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702468526Z","created_at":"2023-11-10T13:17:24.702468526Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622074Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1380"
+      - "1423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:59 GMT
+      - Fri, 10 Nov 2023 13:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3397cd80-768f-4930-a28c-d5e70f09d885
+      - f76e6912-3462-43a4-a274-840dca6d09db
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:59 GMT
+      - Fri, 10 Nov 2023 13:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aebf9c2f-de52-4519-9d0e-7f5110eb313d
+      - ef2c9dbe-d4a3-4d22-850f-a9bbcfd8de2d
     status: 200 OK
     code: 200
     duration: ""
@@ -113,19 +113,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:04 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce08e8c4-a882-4868-a1f5-93257f2d71b5
+      - 3830c0d4-02c6-4a1a-b4b7-d065a65db2fc
     status: 200 OK
     code: 200
     duration: ""
@@ -146,19 +146,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:09 GMT
+      - Fri, 10 Nov 2023 13:17:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5da12ef-c8e0-41d3-9a26-062b48640858
+      - de1c56e1-4395-4a37-b96b-a18b22e578a2
     status: 200 OK
     code: 200
     duration: ""
@@ -179,19 +179,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:17:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48e2316b-735f-40a5-8e50-675bc4738f38
+      - b5b8fdca-1519-4f36-85f1-e26d594927ee
     status: 200 OK
     code: 200
     duration: ""
@@ -212,19 +212,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:20 GMT
+      - Fri, 10 Nov 2023 13:17:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f131f0cd-08b9-4ca9-a1cb-2df3bdac87ce
+      - 2ff4df96-ef46-492f-b081-e5a26e1fbfa5
     status: 200 OK
     code: 200
     duration: ""
@@ -245,19 +245,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:25 GMT
+      - Fri, 10 Nov 2023 13:17:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d75d771a-3bad-45d9-a222-d5503705cd85
+      - f8e092e6-598b-4f27-9b5f-447c8a72aa5d
     status: 200 OK
     code: 200
     duration: ""
@@ -278,19 +278,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:30 GMT
+      - Fri, 10 Nov 2023 13:17:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f82a52d-81dd-4d0e-a6ec-a314618bf1ae
+      - 38a5d5c4-35c8-4310-a605-4b517592e37b
     status: 200 OK
     code: 200
     duration: ""
@@ -311,19 +311,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:35 GMT
+      - Fri, 10 Nov 2023 13:18:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 759d8e98-f66f-41cd-a4ae-63a0f499ed2f
+      - bc123032-fd8d-41ef-ac24-6014798197c7
     status: 200 OK
     code: 200
     duration: ""
@@ -344,19 +344,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:40 GMT
+      - Fri, 10 Nov 2023 13:18:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8341a0e-1642-41c3-aa5c-f0f0f21f8471
+      - 1a525d07-013b-4f67-bf56-891afeeb33ed
     status: 200 OK
     code: 200
     duration: ""
@@ -377,19 +377,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:45 GMT
+      - Fri, 10 Nov 2023 13:18:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3872bac1-aaf5-4d67-ae65-7c97fedb29ae
+      - b8d73092-36cb-42b1-9033-e398f0e10ec4
     status: 200 OK
     code: 200
     duration: ""
@@ -410,19 +410,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:50 GMT
+      - Fri, 10 Nov 2023 13:18:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51ea29a9-0750-4bac-8ecf-1c7be327efdd
+      - 29624ae8-b783-44b9-b15d-f45f8bb99500
     status: 200 OK
     code: 200
     duration: ""
@@ -443,19 +443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:55 GMT
+      - Fri, 10 Nov 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39b0edf0-1a26-4fd4-8941-1bcd17628871
+      - 09cb4e25-7be4-4603-975e-c61020bfc0fd
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +476,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:00 GMT
+      - Fri, 10 Nov 2023 13:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2040195-5251-4cb5-af19-1c58b53f1287
+      - 15dc7b07-0b5c-44e7-8544-74864326db6b
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +509,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:05 GMT
+      - Fri, 10 Nov 2023 13:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd647727-aab9-45ee-9414-90af2f1533c3
+      - 57601bfb-be5a-43b7-b8e1-7126073b9fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +542,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1368"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf7b830a-5639-4efd-9134-b6670ac7bd02
+      - 8ecbc27b-2bd3-41a3-8a56-f3aecf95b038
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +575,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1368"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1295dd0-e171-40a1-a7b6-5f216d7ecb6a
+      - 6de82dc9-8294-4ca6-a611-a6c94c65f341
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +608,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbnBKQ21oV1RtTlhlSFV2Unpka2VFb3lWRzVKTVZoNVZUZ3plV0pMZEc1cU1rcEZXbGxQY1ZabVpHaFpTa2wxWVRGdU1qRlZTVlpNUVZOb1lsWmxlR1ZKTmpRS1FrNVRiR1l6TmxJeVdXaE5kM1l5U0dGSFVFRlpTVzUyWWpNMGNuRkNhbE5hVlZKREwyRnVlbTFXT1ZGeFFXcHpibk52V21aNFdVZHFkQzlMYUdOVlNRcERkbFZxV1hCWFNUWlFaR1J0V1ZKTVEwTlNNbG92UlVjMldqbEhUamhJV0VWUk0wOWlkM0ZHVGsxYVJEWTFjMUZNT1dGcE1FYzNlamxvTlZWMlUxUlJDa0oyY1hKbGFGTTBZV2xETmpaVVJVbG9XRmhKTW5obGIyNW5Wa2RoU25GUlNtTjVTRVJDUkUxM09XTXdNMVpaUm5oR2JqWjVUbUZrUm5OU1NXSnBPRmdLVldKd2FUSlNVVmQyZFhkWFZVcDBXa2xhZHk5VFVUSlpkRVJKVUZSVE0wWldhVTVoZUdSTkwzVTVURzQ1YW5KeWJYWlplRlZWTlVNeVdGUkpUbFpMVEFveGFqWnZUa1Z2Y0hSc1V6TTBaWE5JY1dSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNTOXFkbEpGUlhaT1ptZ3ZLM0JUVTJvMFRFbEpTMnBWZW5aTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFREVjJjMGREVEc5c1MzZHNhMHc1VGtOSVZUSlNOVVZPYUc1NFEwWTBOalptWm1ZMWFuZGlTalZ2VkRBelZqTlFNUXBvTlVsTGFXZENWVzFJYVVVMVZHUjFWakl2WlRKT1QySTRRemxNUmxwYVNFNW5iRFpLYjBoVGVuSkZRMjFuYzBVMk5uVk5aeTl4ZWs1R09YZDVMek5qQ25CUUwxbDNkQzlVU2poYVFsQlZha2R1UzFKSk5rWkhkR2RsYlZKRlMyNUxVekpwWjNsaGRFeGhiVEkwWW5WRVNtSlpiVlp5Y25kUlJsWkpiV0ZoVG1NS04zZHFkamRYYzFOb1JVTkNPVUpaYzBwWWNqTldSbGwyVG1oRE1XaGxabGRJVVRkRmEwRmFNMVZEYm1kWlUxTnZTMjlFWVhKMFRraFlOMlJNY0ZwNWRRcExlRTgwWkdWd2REVjVNekpRTjNrM1dsVjJZM2Q2YzJSRVFWRTBiRVpZTWxJNWFrdzBWREp2Y2toVVduVktUVXRLZGxKME1uazVRMjlyVW5SaWNsTktDak5uWkZkMWR5c3llbVpNTTFoMlQzUk5Na2xWUTNsRGFHUnRSRlJhTkM5WmJtczJaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTdkMzhiMDItNzQ4NS00ZTZlLWFhN2EtZDgyNmRmZGUxY2NmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRalBKYlJWZVlYVHBmczM1bTVjSXJpbklSZjFYcmVzQ1M2ZXNlMGFTTDM1RERPQ3BkNEdIRXpYbw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2612"
+      - "1411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:10 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc550988-22ee-43f0-afe0-480442bc1236
+      - e6416787-1bce-43fe-b363-3f5a93eb843e
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +641,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1368"
+      - "1411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c6e32f-cb7d-44c3-98bf-aadd0efa7151
+      - d7a05b14-06d7-45ee-adb6-dddbf8171641
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR041VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVGRLQ2tSeVFXeHlablEwSzA1UWFHUlJjR2xFUVhkeldXZFRiVlYxV1dRMWJISk5TalV2WnpOQ1pFZEtUMFpXZFhZM09EVmlaSGxvTkhkMlExaEpiR3d2Y0dvS1oyVmpiblIzWjBKWVRVd3hRMDRyWkc5bFNVRlhkMHRKZGxGRlpWQnNhMVJsZGxoRk0yaGlObGRtWlZwNVFUSmxXSEl6Tkdvek5sWXJTalJtYVhCaFRRcDZORThyZFVodE9DOUVhWFpHTTBKSFRFbE5Ta1p2UkcxNlMwSTJSMmR4VHpoMGQybFhSMVJzU1RSSWRHMVZZVUUwYjBaaFRsZDFlbU41ZVVKd1VGTjJDbFpMUVhwYVJuZFlhVTExVEVaclkwaDNNamN4TjJneUwyZFBVV1pVV1ZGWFMySmtVV296YjJsQllrMWFUVXRrTlU5dGJsa3ZiMlJwYm1JMk0wbFNWekFLVEd3NFVESlRXVmQxTDAxWVRtcHBWVGx5YjNGR04weFdhVGxCVlVkRk5HbERkV3hSTHpZd04yWnhXWFpOT1ROaE1UVXlaMGR1Y200ME1sRmxaRTlaS3dwR1dXMDNNRXB0YTNsYVdtTmpSMlZpZDNnd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGFYSXpSMjF6WjFCd2RuVm1SbmhFZGxKV1pGaFJabEpVTlVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVEzYzJhR1o1VkVscGFFMVJUVmRKZEU1dFpIZE9SbTFhYjJGNWJrNWpVMDQzTTFKWGJWRldiak15ZUdKNWQxQkRWUXBOYzJzM1ozZDNTREF2Y1Raa1pscDZVbmRFTVhwamJuRm5WV2RuY2sxRGExWlFaSFpMSzAweU4yVlhjMkpuUWxOcWVsbDJRbUl6ZVdncmNta3piazF0Q2k4d04zSkxOR1pMUmxoYVNrOUpabWhEZUZsM1JVTm5aMDFoZDA1MFduWllNVEF6V0hKUFV6QlFlRTV3TkV0UVQyTlRjVnBJYUdaVlVtZGlLMXBPY1RnS2JWVnljM0pEWmxwbmJXSlJOWGRyZVRSVGVWbElTREpsU205MFp6SmxWVFZJU2pJNGQzcFFkMDF4Ykc5a1pHcGlhR0pRVEZvd1JFbFFaV3hpYmxSalF3cHBjV2xyVmxsamJtRXpUWFpyY3l0T1pXeHJaMnhNZVRSVFJYSXZSVmt2TjNRNVYxSnNLMmhvVEVwS1ZtTk5jRGxJVDBkbVkzSldUR0ZHTTBWVlkwRlRDbWhPYldkNWJsZHhUamd2Y3pJclpuVnlZMGswWW1OSWN6SkhaMEZLZEV4TldUQmxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTlkMGRlOTctMmMxYS00YWRjLWJhYjQtZTVlZjBhMjBmYTZiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRTGhnYkljMnl5MUJXeVNqNmtBR0FoeEtvZzBDcXE3NzBhSHN2aDJqd3RLYXNoRnBOQ1QzVkZxeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2614"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:18:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b69765d8-684c-4456-ba06-facf5ef88f68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1411"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:18:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 690e9bd1-9543-4592-a169-c1967314a8df
     status: 200 OK
     code: 200
     duration: ""
@@ -676,19 +742,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077577624Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274008Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -698,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56eadcf0-a5d5-47e7-8031-7a815aac7bd6
+      - 8e18e8ea-759a-4826-88a5-3f52b01de465
     status: 200 OK
     code: 200
     duration: ""
@@ -709,19 +775,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:11 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -731,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ef229a7-45c1-472d-a978-7b78011604f3
+      - 097c1717-7207-4e22-8795-bb74d134dc0c
     status: 200 OK
     code: 200
     duration: ""
@@ -742,19 +808,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:16 GMT
+      - Fri, 10 Nov 2023 13:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 831fa777-4e5b-4105-bdea-3f877d0ae7ee
+      - cca0dc5b-9009-4262-90cd-c05734977347
     status: 200 OK
     code: 200
     duration: ""
@@ -775,19 +841,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:21 GMT
+      - Fri, 10 Nov 2023 13:18:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa096427-4797-40f9-b296-bf12fcbbfd9d
+      - b345b6ff-e18f-4f3c-8467-59d62b0782e3
     status: 200 OK
     code: 200
     duration: ""
@@ -808,19 +874,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:26 GMT
+      - Fri, 10 Nov 2023 13:19:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -830,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 492e01af-4dba-4c78-bfe6-be4230af4e62
+      - 0ad67bff-f94e-49d0-8182-3bc1bfb2718d
     status: 200 OK
     code: 200
     duration: ""
@@ -841,19 +907,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:31 GMT
+      - Fri, 10 Nov 2023 13:19:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -863,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31efe15c-c599-4cbb-aa7a-1f99fc547fd7
+      - 59db3c77-185f-426b-92a5-5acf1fe73113
     status: 200 OK
     code: 200
     duration: ""
@@ -874,19 +940,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:19:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 114ee06e-1b43-4fc1-bd3b-3bfc5b0064f4
+      - 6c06ddf9-cc1b-4414-8507-e939d5d11e69
     status: 200 OK
     code: 200
     duration: ""
@@ -907,19 +973,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:41 GMT
+      - Fri, 10 Nov 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f6dea32-cd18-4408-ab23-288ed58f053b
+      - 1bc6b2f4-1d33-4fff-93ee-533d6c1d4392
     status: 200 OK
     code: 200
     duration: ""
@@ -940,19 +1006,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:46 GMT
+      - Fri, 10 Nov 2023 13:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3eee73d-6d6e-4cc3-ba98-8b837742219e
+      - 2d63e55f-f06c-429f-9aba-0c5404dcd583
     status: 200 OK
     code: 200
     duration: ""
@@ -973,19 +1039,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:51 GMT
+      - Fri, 10 Nov 2023 13:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 054a94ff-5e8c-4eaa-8c02-b333f51fbd66
+      - fbd956de-c899-440d-9a87-9c13426c46f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,19 +1072,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:56 GMT
+      - Fri, 10 Nov 2023 13:19:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5dd6282-ff08-4713-bf3c-ba55359e2c09
+      - 1563bdac-3de1-4b36-acc4-a79153ce76ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,19 +1105,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:01 GMT
+      - Fri, 10 Nov 2023 13:19:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1061,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e30fdd45-c7a6-4abf-9452-b2a0f77e0a9a
+      - e0c53df1-f614-4c52-bcd1-ad47882a85dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1072,19 +1138,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:06 GMT
+      - Fri, 10 Nov 2023 13:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1094,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09727117-b4e8-47ce-a5cb-cc6d87025ed0
+      - fabbefe7-85ce-407f-80c9-f6393d168e4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,19 +1171,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:11 GMT
+      - Fri, 10 Nov 2023 13:19:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6d5c8c-ea9d-4341-97fd-02df1b4acb17
+      - 3e4c095d-13fa-4d9f-953d-fea5641abd42
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,19 +1204,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
+      - Fri, 10 Nov 2023 13:19:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 277d0512-16b3-467e-936a-d0c5274f2b65
+      - 772d7560-fde7-43be-9fa6-356aa25d3143
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,19 +1237,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:22 GMT
+      - Fri, 10 Nov 2023 13:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed47d484-d30e-434d-a06c-75c4c59cb050
+      - 29df0d64-1cd9-442c-842c-18ab917f22e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1270,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:27 GMT
+      - Fri, 10 Nov 2023 13:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2de33e2e-06e6-43fc-8ddb-cabf734f714e
+      - 7f333b96-7999-4810-b1b7-e835821419e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1303,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:32 GMT
+      - Fri, 10 Nov 2023 13:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f0428a-258c-488b-a116-8e353b42862b
+      - 04c73fd8-575a-4f59-9b0d-5d92bbc43efe
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:37 GMT
+      - Fri, 10 Nov 2023 13:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9222904f-4acd-4a52-93b8-45226659dd77
+      - 12c1e19b-42cd-4a51-9a15-7070b9ccbd23
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:42 GMT
+      - Fri, 10 Nov 2023 13:20:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb517e7e-82ab-4c1a-a93a-ff38f56cc4b1
+      - 8fb45802-af82-4b9a-9eed-3172ccb894ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:47 GMT
+      - Fri, 10 Nov 2023 13:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e73d9e81-4d73-4065-9d96-abbe904ea3b0
+      - 31181a48-58ea-4d80-af45-da8c7841f94f
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1435,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:52 GMT
+      - Fri, 10 Nov 2023 13:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71f4d28a-a29d-42d7-ba30-10ba6f6d9e70
+      - a8e1043d-678e-43e0-b948-0342b0c04571
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,19 +1468,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:57 GMT
+      - Fri, 10 Nov 2023 13:20:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ceb5cef-05c2-470c-9610-8c9b955b65e2
+      - b1d87b64-6151-4d03-a160-8211bb245e80
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,19 +1501,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:02 GMT
+      - Fri, 10 Nov 2023 13:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ca4251a-b1af-4b75-931e-28aea068dc0f
+      - 08e47c63-f26c-47fc-9b1e-5a60ef18a4be
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,19 +1534,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:07 GMT
+      - Fri, 10 Nov 2023 13:20:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a60fea5e-42b1-4958-ae64-e9f1d907008b
+      - 87f7b2d2-3522-4086-8632-a2fb2305aa89
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,19 +1567,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:12 GMT
+      - Fri, 10 Nov 2023 13:20:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7e0bf79-e04b-4b88-8d1e-ac3b8ead1460
+      - dd937685-63b2-47d6-a1fb-cc9bb4d6e2cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,19 +1600,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:17 GMT
+      - Fri, 10 Nov 2023 13:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 162c96ba-f216-4d68-aa69-6e95cb43aca2
+      - 279ff719-ac29-473a-ab69-8be6ed783b5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,19 +1633,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:17 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc33adc4-e827-4dce-95ce-e5c8b4704ec0
+      - 97672997-29a4-409a-bcfb-dfb176126cb0
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,19 +1666,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/nodes?order_by=created_at_asc&page=1&pool_id=a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:21:11.554554Z","error_message":null,"id":"9417a537-4965-4302-9ae6-30f842f612d8","name":"scw-test-multicloud-test-multicloud-9417a53749","pool_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","provider_id":"scaleway://instance/fr-par-1/c42d8e91-8d83-4de6-8dfb-295aa6ac49e2","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:23:14.517625Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:17 GMT
+      - Fri, 10 Nov 2023 13:21:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63edaff7-3872-4087-9e6b-c151d91c9a82
+      - 05b4efed-d658-4672-b9b2-3cce97c3df3c
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,19 +1699,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1368"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:17 GMT
+      - Fri, 10 Nov 2023 13:21:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d24eea9-3cae-49bd-be68-edc584a0a91d
+      - 61e516fd-30c8-43f6-be0b-46cd3f6a5e50
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,19 +1732,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1368"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:21:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33516721-ae9b-4912-b1ed-dbcb690e14df
+      - 3621fbc2-1df6-4730-9938-3cbf89e8f79d
     status: 200 OK
     code: 200
     duration: ""
@@ -1699,19 +1765,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbnBKQ21oV1RtTlhlSFV2Unpka2VFb3lWRzVKTVZoNVZUZ3plV0pMZEc1cU1rcEZXbGxQY1ZabVpHaFpTa2wxWVRGdU1qRlZTVlpNUVZOb1lsWmxlR1ZKTmpRS1FrNVRiR1l6TmxJeVdXaE5kM1l5U0dGSFVFRlpTVzUyWWpNMGNuRkNhbE5hVlZKREwyRnVlbTFXT1ZGeFFXcHpibk52V21aNFdVZHFkQzlMYUdOVlNRcERkbFZxV1hCWFNUWlFaR1J0V1ZKTVEwTlNNbG92UlVjMldqbEhUamhJV0VWUk0wOWlkM0ZHVGsxYVJEWTFjMUZNT1dGcE1FYzNlamxvTlZWMlUxUlJDa0oyY1hKbGFGTTBZV2xETmpaVVJVbG9XRmhKTW5obGIyNW5Wa2RoU25GUlNtTjVTRVJDUkUxM09XTXdNMVpaUm5oR2JqWjVUbUZrUm5OU1NXSnBPRmdLVldKd2FUSlNVVmQyZFhkWFZVcDBXa2xhZHk5VFVUSlpkRVJKVUZSVE0wWldhVTVoZUdSTkwzVTVURzQ1YW5KeWJYWlplRlZWTlVNeVdGUkpUbFpMVEFveGFqWnZUa1Z2Y0hSc1V6TTBaWE5JY1dSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNTOXFkbEpGUlhaT1ptZ3ZLM0JUVTJvMFRFbEpTMnBWZW5aTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFREVjJjMGREVEc5c1MzZHNhMHc1VGtOSVZUSlNOVVZPYUc1NFEwWTBOalptWm1ZMWFuZGlTalZ2VkRBelZqTlFNUXBvTlVsTGFXZENWVzFJYVVVMVZHUjFWakl2WlRKT1QySTRRemxNUmxwYVNFNW5iRFpLYjBoVGVuSkZRMjFuYzBVMk5uVk5aeTl4ZWs1R09YZDVMek5qQ25CUUwxbDNkQzlVU2poYVFsQlZha2R1UzFKSk5rWkhkR2RsYlZKRlMyNUxVekpwWjNsaGRFeGhiVEkwWW5WRVNtSlpiVlp5Y25kUlJsWkpiV0ZoVG1NS04zZHFkamRYYzFOb1JVTkNPVUpaYzBwWWNqTldSbGwyVG1oRE1XaGxabGRJVVRkRmEwRmFNMVZEYm1kWlUxTnZTMjlFWVhKMFRraFlOMlJNY0ZwNWRRcExlRTgwWkdWd2REVjVNekpRTjNrM1dsVjJZM2Q2YzJSRVFWRTBiRVpZTWxJNWFrdzBWREp2Y2toVVduVktUVXRLZGxKME1uazVRMjlyVW5SaWNsTktDak5uWkZkMWR5c3llbVpNTTFoMlQzUk5Na2xWUTNsRGFHUnRSRlJhTkM5WmJtczJaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTdkMzhiMDItNzQ4NS00ZTZlLWFhN2EtZDgyNmRmZGUxY2NmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRalBKYlJWZVlYVHBmczM1bTVjSXJpbklSZjFYcmVzQ1M2ZXNlMGFTTDM1RERPQ3BkNEdIRXpYbw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2612"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78162fc0-40e3-40f8-912f-8880815c33a8
+      - 07e943b2-d2a5-44f4-87ee-8bf9b4f1de26
     status: 200 OK
     code: 200
     duration: ""
@@ -1732,19 +1798,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:21:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0a1ac35-71b2-4b90-b680-82b8802b7d88
+      - a2409326-41b6-4b0c-94dc-f2d80897cbc6
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,19 +1831,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/nodes?order_by=created_at_asc&page=1&pool_id=a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:21:11.554554Z","error_message":null,"id":"9417a537-4965-4302-9ae6-30f842f612d8","name":"scw-test-multicloud-test-multicloud-9417a53749","pool_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","provider_id":"scaleway://instance/fr-par-1/c42d8e91-8d83-4de6-8dfb-295aa6ac49e2","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:23:14.517625Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:21:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff4598a0-fcfb-462e-a387-7f3c855d5caa
+      - c1d9b7c5-9d36-4681-b2cd-2db0a8754189
     status: 200 OK
     code: 200
     duration: ""
@@ -1798,19 +1864,250 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8fe364c-001f-42f4-beee-83d467f3bdcc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/nodes?order_by=created_at_asc&page=1&pool_id=5e5090ef-8f8b-49ca-9a70-5745d4c73e64&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:18:47.010268Z","error_message":null,"id":"d8b762fa-0076-4fdc-a780-71680316da25","name":"scw-test-multicloud-test-multicloud-d8b762fa00","pool_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","provider_id":"scaleway://instance/fr-par-1/f3fcb31c-19bb-4a6d-8d57-a74e3cc6a1ba","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:21:27.302280Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "621"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aad245cf-b27c-4509-8472-df6ac699b67e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1411"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 325edf3b-9692-4403-8411-390a3a6efa63
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1411"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a57c1b0d-67bf-4858-8f5e-9d0c8c41afe9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR041VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVGRLQ2tSeVFXeHlablEwSzA1UWFHUlJjR2xFUVhkeldXZFRiVlYxV1dRMWJISk5TalV2WnpOQ1pFZEtUMFpXZFhZM09EVmlaSGxvTkhkMlExaEpiR3d2Y0dvS1oyVmpiblIzWjBKWVRVd3hRMDRyWkc5bFNVRlhkMHRKZGxGRlpWQnNhMVJsZGxoRk0yaGlObGRtWlZwNVFUSmxXSEl6Tkdvek5sWXJTalJtYVhCaFRRcDZORThyZFVodE9DOUVhWFpHTTBKSFRFbE5Ta1p2UkcxNlMwSTJSMmR4VHpoMGQybFhSMVJzU1RSSWRHMVZZVUUwYjBaaFRsZDFlbU41ZVVKd1VGTjJDbFpMUVhwYVJuZFlhVTExVEVaclkwaDNNamN4TjJneUwyZFBVV1pVV1ZGWFMySmtVV296YjJsQllrMWFUVXRrTlU5dGJsa3ZiMlJwYm1JMk0wbFNWekFLVEd3NFVESlRXVmQxTDAxWVRtcHBWVGx5YjNGR04weFdhVGxCVlVkRk5HbERkV3hSTHpZd04yWnhXWFpOT1ROaE1UVXlaMGR1Y200ME1sRmxaRTlaS3dwR1dXMDNNRXB0YTNsYVdtTmpSMlZpZDNnd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGFYSXpSMjF6WjFCd2RuVm1SbmhFZGxKV1pGaFJabEpVTlVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVEzYzJhR1o1VkVscGFFMVJUVmRKZEU1dFpIZE9SbTFhYjJGNWJrNWpVMDQzTTFKWGJWRldiak15ZUdKNWQxQkRWUXBOYzJzM1ozZDNTREF2Y1Raa1pscDZVbmRFTVhwamJuRm5WV2RuY2sxRGExWlFaSFpMSzAweU4yVlhjMkpuUWxOcWVsbDJRbUl6ZVdncmNta3piazF0Q2k4d04zSkxOR1pMUmxoYVNrOUpabWhEZUZsM1JVTm5aMDFoZDA1MFduWllNVEF6V0hKUFV6QlFlRTV3TkV0UVQyTlRjVnBJYUdaVlVtZGlLMXBPY1RnS2JWVnljM0pEWmxwbmJXSlJOWGRyZVRSVGVWbElTREpsU205MFp6SmxWVFZJU2pJNGQzcFFkMDF4Ykc5a1pHcGlhR0pRVEZvd1JFbFFaV3hpYmxSalF3cHBjV2xyVmxsamJtRXpUWFpyY3l0T1pXeHJaMnhNZVRSVFJYSXZSVmt2TjNRNVYxSnNLMmhvVEVwS1ZtTk5jRGxJVDBkbVkzSldUR0ZHTTBWVlkwRlRDbWhPYldkNWJsZHhUamd2Y3pJclpuVnlZMGswWW1OSWN6SkhaMEZLZEV4TldUQmxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTlkMGRlOTctMmMxYS00YWRjLWJhYjQtZTVlZjBhMjBmYTZiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRTGhnYkljMnl5MUJXeVNqNmtBR0FoeEtvZzBDcXE3NzBhSHN2aDJqd3RLYXNoRnBOQ1QzVkZxeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2614"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edd68956-b1f9-4f8a-98e9-613650fa71cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 80b7c041-9ff1-4f16-be10-a6d0b42b00d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/nodes?order_by=created_at_asc&page=1&pool_id=5e5090ef-8f8b-49ca-9a70-5745d4c73e64&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:18:47.010268Z","error_message":null,"id":"d8b762fa-0076-4fdc-a780-71680316da25","name":"scw-test-multicloud-test-multicloud-d8b762fa00","pool_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","provider_id":"scaleway://instance/fr-par-1/f3fcb31c-19bb-4a6d-8d57-a74e3cc6a1ba","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:21:27.302280Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "621"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9a9ebf1-d0fa-4526-96e6-bccf1cb245e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333276Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1820,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35c33d37-96b4-4b1a-8c6b-68fc8539b066
+      - a213b420-3576-462a-8488-fa7dfa395eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1831,19 +2128,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:19 GMT
+      - Fri, 10 Nov 2023 13:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1853,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0e1fb39-d094-48ef-924e-bc1e364bc1a6
+      - be00a1be-ea3f-4f3a-804a-c380694f7e05
     status: 200 OK
     code: 200
     duration: ""
@@ -1864,19 +2161,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:24 GMT
+      - Fri, 10 Nov 2023 13:21:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1886,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17a43dd-f264-40bb-bc83-affa5ddbfb25
+      - fcee68f2-ee6f-4f96-bb0c-7321b3250ab5
     status: 200 OK
     code: 200
     duration: ""
@@ -1897,19 +2194,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:29 GMT
+      - Fri, 10 Nov 2023 13:21:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1919,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165c5990-5bbc-483e-9022-095e32bfef73
+      - 3f2ece7e-8539-43f3-81d4-624e75d80dbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1930,19 +2227,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:34 GMT
+      - Fri, 10 Nov 2023 13:21:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1952,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b408659-35d2-4067-8311-8b05726ffc04
+      - f5ae4b0f-2f7e-48b7-a1a9-6779d223e1cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1963,10 +2260,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb204dcc-f776-456e-a700-6e27e6ddc312
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:21:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eda294f2-b029-4e7b-b674-b4047445c3e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3453353-11a1-4894-b267-dd3b73d8f710
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 004d0d62-fe95-4d2d-8b93-e4e63a096704
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -1975,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:39 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1985,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20287aba-3a89-4f7d-9f17-23b17d4848e9
+      - 028432e3-d4a7-4ac7-9ab2-c7665699a5c0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1996,19 +2425,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255802878Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497064848Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1374"
+      - "1417"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:39 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2018,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc6be094-8e5e-404d-a3ee-09806e845eb9
+      - 4165f7bc-9314-4239-9bb6-3508f4823692
     status: 200 OK
     code: 200
     duration: ""
@@ -2029,19 +2458,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:39 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2051,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34d3c1de-c641-40ac-81c7-3de9c1dd73d4
+      - 4d57c21f-2607-41fc-a7f3-52e4338e91c1
     status: 200 OK
     code: 200
     duration: ""
@@ -2062,19 +2491,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:44 GMT
+      - Fri, 10 Nov 2023 13:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2084,7 +2513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b35e551c-4749-42f9-8dbb-2e857587b170
+      - 080b8077-971b-47fe-bc47-903d455086a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2095,19 +2524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:49 GMT
+      - Fri, 10 Nov 2023 13:22:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2117,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8e2f9b7-3b5d-4c5d-a427-cbe737d49a68
+      - d20671f7-6b3b-4282-818f-3845e39f38ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2128,19 +2557,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:54 GMT
+      - Fri, 10 Nov 2023 13:22:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2150,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3151e7f-441d-4166-b245-19a55bdf8dfb
+      - c5d6b070-95d4-4222-a588-d972d71ea45c
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,19 +2590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:59 GMT
+      - Fri, 10 Nov 2023 13:22:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2183,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 895cec2d-687e-4c61-931c-881dd8022f39
+      - b3ec7036-1e3a-41d3-8ece-dd222f396455
     status: 200 OK
     code: 200
     duration: ""
@@ -2194,19 +2623,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:22:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2216,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a64af48-2710-4549-8711-f5e3c36aa77c
+      - f7c247dc-69b9-4917-9f77-943327547577
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,19 +2656,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:09 GMT
+      - Fri, 10 Nov 2023 13:22:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2249,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af450e1d-a395-49fa-9660-ed860f46529a
+      - 126a53a8-0f1c-4374-a1d7-678199ecadbd
     status: 200 OK
     code: 200
     duration: ""
@@ -2260,19 +2689,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:14 GMT
+      - Fri, 10 Nov 2023 13:22:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2282,7 +2711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ba6dea-49ee-4733-9c33-b6e2933b2637
+      - c5d60d2b-28da-4644-9482-91f5336a5bc1
     status: 200 OK
     code: 200
     duration: ""
@@ -2293,19 +2722,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1371"
+      - "1414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:19 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2315,7 +2744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2461f7f9-2768-40e2-85d5-438aaa089f24
+      - 42950e1a-5314-4d97-b8c5-89b794b0a723
     status: 200 OK
     code: 200
     duration: ""
@@ -2326,10 +2755,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2338,7 +2767,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:24 GMT
+      - Fri, 10 Nov 2023 13:22:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2348,7 +2777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e23fca6f-67d4-42c6-b9a0-bea5358e2c1f
+      - ed1a08dd-6e02-49ee-9e11-80daa0873974
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2359,10 +2788,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2371,7 +2800,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:24 GMT
+      - Fri, 10 Nov 2023 13:22:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2381,7 +2810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60791f34-5bc3-4c6e-ad20-3507871934ae
+      - c301e144-fe24-464a-ac22-36be3cc55dd4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dc646c0-ee24-4b8f-8c74-ad9e67188c40
+      - 6fec77fa-2a71-4f46-9eba-6bc66e3a8526
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "692"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:30 GMT
+      - Fri, 10 Nov 2023 13:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fc122c9-89ce-412a-af08-59d415e1d184
+      - d0b10d23-c4f6-4d45-a6ef-c14aa02d93c6
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "692"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:30 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b6e62e-94b0-413c-a0a8-0d99d4f91be7
+      - 251760b1-d823-427d-9a33-e7cc1d14db02
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"75b19688-d376-414a-ae89-26f0b815d552"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281180Z","created_at":"2023-11-07T16:21:30.709281180Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:30.727658596Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335320Z","created_at":"2023-11-10T13:16:58.492335320Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501987724Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1566"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:30 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ed6eeeb-4a41-4556-b72f-10afa206e96c
+      - ce6d48e8-d9a6-4b3a-9fa5-6dd6577678f8
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:30.727659Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501988Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1511"
+      - "1557"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:30 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85468541-e283-41d5-93f1-a493085fcb69
+      - 119c37fe-99ee-4ad5-8b71-8b5eb6cb250c
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501988Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1557"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:35 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a78f1e-6aa3-450d-9824-e82ac5452e36
+      - 7c69278e-0600-470a-b244-8b627a1d613f
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1562"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5ba4705-7cce-4342-bea6-6f83577a850c
+      - 409ca66c-aaec-40db-8be2-2da897ca80b4
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2564"
+      - "1562"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 341a18bf-dcef-46ba-bc9d-fa56150437c3
+      - 871c4843-c48d-4a68-b75f-650bc2bd3f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1516"
+      - "2566"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 695f451f-d711-4b84-baba-332b76c5db77
+      - dddfee2d-dff6-4153-805b-6f0f37f2d84c
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "692"
+      - "1562"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ac296ec-b409-47bb-aaea-f3e1ea6e627b
+      - 9b97e573-3381-40e1-926f-fe705bd43ad5
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1516"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd8ac5d9-bdc2-4086-81eb-6eae6573f998
+      - 3b0e7f0e-e0bc-4ec1-b832-fe2c87770b3b
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2564"
+      - "1562"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:36 GMT
+      - Fri, 10 Nov 2023 13:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03372729-0ae5-40a6-a85e-2689ae331448
+      - 27816e79-e6fd-430c-8e25-ade4229549e0
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "692"
+      - "2566"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:37 GMT
+      - Fri, 10 Nov 2023 13:17:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e243f3c9-ed33-4000-bd58-69b394db11ad
+      - d26cd1c5-561c-4ccc-856d-6748e4454c63
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1516"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:37 GMT
+      - Fri, 10 Nov 2023 13:17:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdf8b81d-107a-464c-a1bf-aeed6b504d14
+      - 2e1fe35a-63ed-4373-b39f-112b503dcab7
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2564"
+      - "1562"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:37 GMT
+      - Fri, 10 Nov 2023 13:17:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54c9907e-4578-4ea0-b871-a463a9739674
+      - cf45cd41-8536-4a39-9d67-218c831aca8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2566"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bc54d880-9385-4a7c-afcc-db43ce08f209
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:37.798781702Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:11.708006202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1548"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:37 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af61d58e-675f-4975-bc5e-2d0c20372b1e
+      - f95440b3-c117-40be-8f2d-0cdae7825d03
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:37.798782Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:11.708006Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:37 GMT
+      - Fri, 10 Nov 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bd3e533-cb3c-4837-9f4d-0a79d24650fa
+      - 292b5c1b-6755-435e-a755-8a8562a9c6b6
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:42 GMT
+      - Fri, 10 Nov 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 235ce950-c95c-4bd9-a33f-f7a18da60630
+      - 2583bd70-11ca-473f-a702-6b32ac5ac748
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:42 GMT
+      - Fri, 10 Nov 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87aac7b8-1017-4b4a-97bc-d0c1ac3084f0
+      - d11cead5-6382-44a6-8d75-aeaa5d9fef41
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2564"
+      - "2566"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ca886c7-be28-4825-ae42-39da36d4e610
+      - 970cd56d-1d6d-41ca-be77-9308a97b3447
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b0b0888-4e71-4dab-a2c1-f2d25a332e6c
+      - 9cd3fe39-835c-445a-8adf-277bc2304fd0
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "692"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f29d9a37-132b-4064-a5ad-2166b7462aad
+      - 82c5446d-7dc6-446b-90e9-1d85e222f8e3
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a9ec5f0-b590-4849-ab91-407277c70082
+      - 8cb4f0a3-30d6-4896-bfcf-3917ca8ce3ed
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2564"
+      - "2566"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:43 GMT
+      - Fri, 10 Nov 2023 13:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0988a75-0903-4d2f-b592-cda0fccb7a5d
+      - 41c301fd-37e2-4c15-99c4-5873008191b4
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152962976Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899108689Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1548"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:44 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e190eb33-88bb-4d81-9099-ea2f71f8785e
+      - 565e03d5-7c9c-450d-b2e8-00075843d6f8
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152963Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:44 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19ffee05-beb6-487a-b10f-499ae44121bd
+      - 10e8a8c1-691a-471a-9434-c9410854b6d7
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152963Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:49 GMT
+      - Fri, 10 Nov 2023 13:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a874da6-be8a-41c7-a599-5b467a8bbff3
+      - 67418668-edaa-4cf4-af7f-25448c5ae7e8
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"36b457ff-8f98-4c0c-b634-97d933bb7231","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -921,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:54 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 230213d0-783b-4c1b-8616-871f54b6782e
+      - abc57616-21e4-4252-961c-a0e2540866b6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"75b19688-d376-414a-ae89-26f0b815d552","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -954,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:54 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c5d658b-b7f2-4649-b940-efc0b184ff4e
+      - b66c5fdf-0675-46dd-98a2-38cfed3541f3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -975,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"75b19688-d376-414a-ae89-26f0b815d552","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:54 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +1030,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f44d52e-7236-42a8-8fd9-0a7cafd13f16
+      - b34ef129-06a7-48e0-8bac-b4cebc465811
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"36b457ff-8f98-4c0c-b634-97d933bb7231","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c15761ce-1f51-448a-a934-aae30cd189ec
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4877670d-8348-49e1-b0bc-f9fe59a7e304
+      - 3e0562de-3bb3-43d9-b98b-79477751cf98
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-minimal","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-minimal","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:53:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3bb2822-348c-4c2d-b1d2-ed6b610d6b0a
+      - b314080a-47b8-41c9-bbf6-bf23c29fde4f
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c16fed30-4ac3-473c-bb75-d9ea662920dd
+      - 9ce36cd6-51c9-4aaa-8ba2-32d4c1823fb4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503255Z","created_at":"2023-11-07T15:49:53.386503255Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.416457093Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667384Z","created_at":"2023-11-10T13:53:19.364667384Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:19.376319005Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1464"
+      - "1509"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb5d77e4-d80a-4efd-8e1d-211c77f4c082
+      - 44a7531b-a267-476c-8419-381147aba260
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.416457Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:19.376319Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69c83971-9ea9-4bab-a255-a8553988e9ba
+      - 949cb28c-a0a1-4f95-8c94-8a597ca6f61d
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1460"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f645a74-d840-4c21-9b88-85f87b5cea6a
+      - db1edc51-03b9-4e82-b710-83573322fd0e
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1460"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13c4a77e-7507-4d9d-a5a4-1d9cb640c392
+      - d358e946-cb5a-4e33-850b-d418a93d9f4d
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1506371-4eea-420e-a819-b511cfa7aab9
+      - d0e89944-06f5-4db1-bfcb-767507cad3b5
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1460"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 878b7a5f-423b-4200-9c09-06f677c50d55
+      - 99af0b99-4d90-4e96-8a16-8c0a3174d070
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867037882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "656"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:53:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c2e70df-26fc-46d6-9da7-b5d6d0eb0955
+      - 56dfcb50-7acd-4c10-9137-46fdd9d380c6
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:53:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ab2716c-1e83-4c05-bda5-297e139dc8e7
+      - 4832da43-3aa8-474f-b335-4e54d7ef8645
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 373c2f98-33e3-45ba-9470-7bc6e110a7a2
+      - d92c32ac-f4c6-42ad-814d-7f410fdc3af8
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95fef894-911a-4a26-b57b-d874f2828bd4
+      - beaf30b5-2389-4832-8de2-48130e5fff42
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf31eabc-d711-4d0d-be5a-5ab1a0b34a11
+      - bdf7fd96-d1a3-4fe6-a273-1898b4ed3ebe
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:53:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ced4d004-1225-4a18-b14c-f3cd1fb5ad99
+      - 0582dd31-42ab-4b23-b7a0-4976250a31ab
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 259c939c-552f-4282-b370-7951df0531ae
+      - 5278eab3-f18f-4bb4-beb1-bcd8624e08e6
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:53:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbf52ae6-a615-4640-a857-a601b03aca84
+      - 68480433-84de-452e-a842-fa414fb4e30e
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:36 GMT
+      - Fri, 10 Nov 2023 13:54:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 376d83f5-aca0-490c-98eb-fbc74b28b5ff
+      - 820be7be-6788-4d26-a385-316637bb24c8
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:41 GMT
+      - Fri, 10 Nov 2023 13:54:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f06cc32-db37-4f5e-8770-5eecbc9aca47
+      - d1a50d6d-5777-410a-a2ba-9ccf6ee6baad
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f91aa7ad-18bb-4a6e-9745-71709780433a
+      - 87216dbc-4396-4c75-8d4f-e9b844480177
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cece5114-293b-4bb9-aab6-a31bfe6d96e8
+      - b7175a3d-6b83-41a5-8918-7aee44a3a11d
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a2a77a5-eaec-4cc7-b0aa-09378345bf21
+      - 0335f989-71a9-445d-bb73-e2b3e36f72df
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2275e62-890a-4ff2-9f89-4956f4209881
+      - f4d3d888-10b1-4236-9cc0-6d86a1f9dac3
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:54:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cdb51d6-0ea7-4486-a03c-a994f46aedc0
+      - 1ebed78c-30d9-4037-934f-943589fcaee3
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77ec7840-53b7-4a3d-a511-ef033c02e2a9
+      - 27825292-d076-4952-93c6-a58c7999c420
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a9832df-4650-4818-8319-ed15fa46ee9a
+      - c8a506e7-a617-437b-a551-6470a3f9e61c
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c1afcd-6280-4c8b-a22f-b86cc250d369
+      - df7f509c-820f-4a39-a24c-cd7d3672c548
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c711bb87-8560-4baf-bedb-b3784511c192
+      - 8bd215f9-cf50-45f8-a6ac-d5a6ecbb322d
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:54:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f05e4dd0-80e6-4943-b850-323722284050
+      - 791f09ca-ea00-4eb9-abc2-b4e223b6c8ff
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:55:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce091863-dc59-469a-a20b-f314e72b36da
+      - 70f9ee08-5d47-4f93-9554-a96eadf7be45
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:55:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 932a8be9-2115-4379-a8c1-363d53a03ab8
+      - 38d04b14-8bfa-4153-89d8-c3cbd1ae0d58
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60680f78-a1a1-41c0-8485-179cd1f7cb33
+      - e416376f-729c-472e-b7de-592e017be395
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec06d766-f411-4f05-a6f5-a5bbc5da1dfb
+      - e79749fd-0a2a-4429-9a41-18857f4dfe10
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ab7cec3-7c32-4138-89fb-ef6ed8707d2e
+      - cd67142f-f373-45cd-88b3-b61bf8664049
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:55:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8930c57b-5695-4ed1-add7-b7f2e7e76482
+      - fbf6261b-7ed5-4a41-bc04-cb15f1a1ff01
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:06 GMT
+      - Fri, 10 Nov 2023 13:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49895f89-df11-4704-bf24-49702accfa09
+      - f0db538b-b380-4b37-83ce-366b8888daa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:55:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ca85257-b1f1-4ff6-8a8a-115e6fae1668
+      - df676c69-d45f-4222-a65f-06d4757b92c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acdbde9a-04c2-44ce-bf20-0980c2d822d5
+      - fe86561d-d8d5-45f4-9c07-1428be80e716
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e95d85b-8d0c-47d5-a80e-65f7be2c20e8
+      - 30c1258a-88a3-4fb7-ac64-f7441e9eaf69
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfa4b34f-f483-43e7-b154-b0594eae7bb7
+      - 99a9cf27-4e86-41bb-ac6e-615d9e67ceb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c05c2ca6-197e-464a-832c-17e79dd3e2a1
+      - 22185d57-2fe4-4537-b7ad-37bc157a590a
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:56:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 069a75d6-3ee9-4ad5-bbd6-4589788b6543
+      - b709a2d2-5f15-4d97-aa09-d2912f562d69
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:56:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d818dfe4-fc69-4dc2-8463-6809c7bbc713
+      - edbe1229-e32c-4df9-911c-b83d405950f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67014b06-d366-4fde-8a01-588a693e5004
+      - eb3211c8-c169-40cf-a491-670f362f2fc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c5902e1-f6e4-45ef-9633-d55cc00190c9
+      - 6eba8e19-e1c4-40ee-bf9c-34151ac84852
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08ad9460-0cbf-4840-8053-9b2be77c2bbf
+      - 73202415-27d1-4e3d-a150-80680c12baaa
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:56:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9429696e-63b9-4689-bd0e-78f3563b7c28
+      - de76df04-56c4-46fa-abed-560cd87c7189
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:56:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b80f0231-2d91-4cb6-95c6-41c9fa1ff51b
+      - 3eeb0a3c-6266-4e4f-a793-09fa52e3b56b
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16941dd1-8cff-4500-921c-b99485fffb9c
+      - d6d53f91-d95b-47f0-b504-6a63bfc5176b
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:56:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39080ace-0b00-4b5a-a59f-4019ddf139b3
+      - 1f808fe1-1b4f-43e0-baba-a9281b989df2
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b40708a8-4be2-4aec-8346-519316a270a0
+      - 9f335fc4-b1a7-4109-a1bd-eee00c8c699a
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:56:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f64046d-26d8-4553-9aed-f6fb110fc51b
+      - 6250f6e9-1267-424e-ac43-9b43395afe28
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a17e41-c0c5-4d64-8d06-2fd8cdd1f938
+      - b4d2a682-df13-4fad-b496-7fc0496806b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a9ae899-8e2b-4489-a036-668b66e276f3
+      - 0de28af9-a435-4343-b10e-f3a29bbaa22b
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:57:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46ca0e21-9811-434b-b590-fd0794085f9a
+      - 94c368dc-1699-4e19-b232-db4b8ee341f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83683237-e5ec-49da-870f-a7e7e8487223
+      - d268c6c5-1e3e-4b7a-8b80-53cfce30333d
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbdcd247-8e85-43d9-9b70-7b50a6a971be
+      - dd5db71a-2d98-4a87-8400-1930e4911274
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21d80369-3a52-42a5-8f3b-9a80fd030062
+      - 9367c3c5-b0a2-4e5e-992c-3bfeef53c527
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb7b4ae9-f375-474c-95c4-5110664bf999
+      - fb83b3e2-51c9-491e-b3a5-fe697c31299d
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 103b9c93-934e-466b-ba8f-3af7aead01bf
+      - 674630f5-f4f3-4ca2-8cd8-fff408dcca7a
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5dbc01c-e4e5-4b95-90c2-ffdcb670c639
+      - 45e88f48-1491-40d1-94dc-2321a73eee3b
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0f7065f-bd3f-469f-bd6f-db64aa15f0e7
+      - 59039427-7c20-4616-8d79-4e117afe6ea7
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e86774cb-7d29-4d32-8f19-ac9861e18b22
+      - 64ed7c7f-692b-47b6-84c1-b4a09dd4b4b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1452"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 803e7a9f-519c-4ebb-a688-4d8366ffa600
+      - cdce6f44-b992-46bf-9334-c8aedf7a9bd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "651"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab2e99d-4d51-49a6-9098-133bf7f8c06b
+      - 059ea1c0-5810-41b3-a346-8b61b0b87e3b
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3536b9c-87b0-4205-bafc-4761d42d4415
+      - ce59da59-e75a-4a8e-8cef-051a3b10776e
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1452"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e073309-5e13-4d8e-8a54-53e443dfee65
+      - 78ca7618-efbd-4613-bfe8-08ede38f9889
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "651"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ba1b714-12c1-4b39-9e66-e72a0ee60a45
+      - 0158707c-e895-43d2-bcf1-5114ecb60395
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "701"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c4ae48d-b624-4931-b7ba-cff9ac6cf185
+      - bf9a2883-1ba6-4a13-bb82-e0418ab725d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1452"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1acdd6c-7780-4363-bc18-673c1ca13a1f
+      - bd90b977-cd0d-4f00-ac87-db5247cf904d
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2628"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7af329a-b907-43bc-9ca4-f7c63c9f97a5
+      - c4a299ec-452c-4f69-b939-472177aca652
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "651"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34c72fb4-e0a9-4b8a-ab02-8994db0dff8e
+      - 136b6bc8-1cf4-4195-a182-e860d3421c0f
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ad1b5c4-fb78-4fc7-8015-20ad21c6e5d6
+      - f13eeea0-171b-42b9-92d7-c3ace9122e54
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "701"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae1db4b-93bb-4aee-86f1-6f0e0a0ef8ce
+      - b9fd42f8-1e26-406f-a4a2-bfc183d9ec05
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1452"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77eb6e47-c9dc-42c7-9f36-a7c5e517047b
+      - e54f3cab-5714-4edf-9c9f-955232c06eae
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2628"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 592f7afe-e09e-41d3-8176-3108bf06580d
+      - 89373571-f4da-49e8-9c4a-e52926810aeb
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "651"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32dd99ff-2e63-4dc1-8e59-3193b637982b
+      - e66614d4-803a-41a1-a277-68d490d154e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8320043-f8d5-4c36-8658-83bc3387ab99
+      - dcec536b-a394-4fff-bf67-950882e28087
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1452"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2614,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e1cd056-38df-423d-8623-0541763d9d67
+      - 37ba134c-ed38-4314-9bf9-14f404f012ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1497"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:57:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 062a65e8-b8a1-4c9e-811c-98d010526a41
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,10 +2660,1132 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426475Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030121Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "683"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:57:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f068075-6914-4fb2-ad23-2dd4eb38a859
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:57:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8e6512f-6a02-43b6-bd64-71fbd6b12ef2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b9c11d6-5b5d-4b6d-8c5b-7ef7147c3863
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e632a333-f5ac-4b6f-a4ab-8912adebbeca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34018653-2fec-4432-9af7-23ca6a07203d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68fb90ca-5964-4f0d-bc2d-f684f59d4c85
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf055a07-0e6a-441a-9365-741eaa1e2e9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf2d25fa-283a-4df9-94f2-9e3ec6582b5f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69151ac1-4473-45a0-bb05-bc0f8283ca36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8260134e-085e-4f7f-9ca0-84848632c22a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01dd5dd2-0ec4-4b9b-bc93-a5845bbc38fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f2a31dd-897d-4ffa-a59e-3d0f0f876f78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae84bd45-88fa-4bc9-9fec-ae32967f868c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:58:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b982ba9-0247-4cd3-b357-3df2fb7ea273
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab4c6ed5-c8ce-4053-8c27-4e3825ef48d9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66b02432-b021-4123-89c6-2052e2e5d9ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c07d044-2d55-4eb0-b1fc-ea5f84b12f67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52704ca6-aab7-4ebb-b2c4-2ceaf6461723
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1b383a1-27b3-4ddd-b284-331097286970
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e31d729-b970-49ea-a982-bbf8bcc487ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7690326b-1cfc-4963-b35e-9220d5d7fb2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d337fa6d-76d5-4ce4-a35c-ce5015645b98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b343d31c-52d3-49a0-97b9-d135a198771d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a63b9761-2eb8-43ea-8d8a-2af17eb716a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:59:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 380b601f-13b7-49aa-bc61-8f953fe3ddd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e890ec4-1f6a-42fc-856b-78078ea53514
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5cbb5c4f-dcc0-4a14-89cb-13ab870165eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41fdfa45-f152-4dab-a3ca-01ee4b961834
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 898a97e6-e565-4587-acd2-93ad5894ed02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d568c7de-b0e2-4f14-bb03-d48568889180
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c0e3d3a6-27ec-4d0e-9dcc-1652f3036173
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a11091a-1ea8-4db0-9fa1-bf15368f4aba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b131b979-4672-4082-9068-8ba712183f41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:00:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd5a374c-a855-4b06-a9cb-0a419fb43ba6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "658"
@@ -2639,7 +3794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b900f4d7-dfa5-4e24-b8e0-099531cc39c5
+      - 45a9ca64-23ec-41a3-8e62-fa9841dd119b
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,19 +3815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "655"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e8afc70-c782-492d-87e4-d00633d1b435
+      - 4689023a-06d7-49c4-bed2-f4d72c2c75b3
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "655"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:31 GMT
+      - Fri, 10 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c6eb122-c9e3-49b7-97e9-ad3f20b6485e
+      - 13ba8156-ab12-4cee-961d-9684ed1b064a
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,19 +3881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "655"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:36 GMT
+      - Fri, 10 Nov 2023 14:00:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbf394a7-eec8-4b1b-8677-53d926badfe5
+      - 15fdafee-9942-4e04-a242-13864f26dfdd
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +3914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "655"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:41 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d8240c2-b6b0-45d2-9884-80848ebbf545
+      - 00eb91a5-2464-48c6-a992-ed43b71bce9e
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "655"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:46 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94f95703-89d5-4a01-ba14-4843e3aa5ca8
+      - 15804155-5704-4288-8c9b-9ce3d902c61e
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "655"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:51 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13a60d2d-c86d-40b6-a810-538a87f5693a
+      - 99c52baa-3802-44b3-875e-e7fcb8676f8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,19 +4013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "655"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:56 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1abff5b9-c841-4b41-b35d-5941dca01ae1
+      - 47798042-c1b6-4e6e-8f65-ff802529eb51
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,19 +4046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.458668Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "655"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28df22f9-501a-4850-8a74-1093320a564d
+      - 8b006236-e160-4147-abd3-170cedcb6f00
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +4079,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "655"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:06 GMT
+      - Fri, 10 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 545e54f4-76cd-4e1f-a560-7940158d9e03
+      - 23845016-f2ad-44e3-b810-216a401e6f76
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +4112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "655"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:11 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fdd257d-ea67-418c-9d34-e49ca4bdd40b
+      - 12243361-a64d-405e-b749-02a2488f550f
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +4145,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "655"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:17 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6e8dd06-abff-4587-a405-b72e963823f4
+      - 9c09a62c-f077-451c-b664-d7fbd1c4093b
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "655"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:22 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b2375dd-84fb-47a0-979a-53e0c7439fdf
+      - f204aee1-5324-4603-b501-b20c71d0dc68
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +4211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "655"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:27 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ba9c1e2-4a7a-4058-b416-b4ae46a262ac
+      - 2cbb8ae3-2951-4372-aa86-1b85036ef653
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +4244,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "655"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:32 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcbf2348-0c2e-42d5-ad57-c24e7459eb61
+      - 8b795e98-1d51-4c20-982c-b56628abf88a
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,19 +4277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "655"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:37 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a73755e-1d62-43bc-b632-bc0fb04bb259
+      - cf29439a-f2bc-4d37-82d3-efdf936a5575
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,19 +4310,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.458668Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "655"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:42 GMT
+      - Fri, 10 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 076b8277-e88d-4b57-82a6-59e2222b43e2
+      - ab1503ea-a95b-45ff-91c1-ee996f3ee45b
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,1207 +4343,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5bdda78d-ede0-4652-996d-ec723177004f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90a46396-784b-4064-b0ee-12b3ce946dc1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e0a9f82-44f9-4225-9e0c-2cd8f242c382
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5604c6de-3dab-49fb-abab-8aa1d6258856
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0ee29ebf-c6be-4df5-b25b-b29595ec5423
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff287062-dcef-4c20-8ff6-fa978480bee9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e6132f24-7f0d-4b67-8572-87cd62f52b8e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2006ce02-0d14-4db8-bbd7-a37f7d8c8b57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f67f659-4ec7-473e-8d4f-6a6c0899d9b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 63945639-5b0e-4036-a7eb-0e86fe5c3cee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 93bbdc43-4f61-47da-9ef1-712c6ec980aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6911ebd9-61b8-48dc-a9b6-457d66429ac4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c129d64-16b8-46b0-9419-a7322d1f458a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c5c30e5-3a3f-42a9-98e7-304ac8864d6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2af045ce-5338-4a52-a7b5-e31e5d51395a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1a5d32c-3c5d-4fba-a51c-6deab9d135b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "655"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06b0f13a-2207-48b3-bfde-aaea28371255
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "653"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c989ba46-08fa-4e66-9d77-34b0c7b1be76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "653"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f251dd03-48eb-4d1d-b8c9-1079fc36a49c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ce13d67-7e7c-4aef-8157-8866c1ed6fc4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1452"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f04dd7b4-45bc-4d13-8a68-7d584e3948b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "653"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c096a3f-c410-43ab-a4ed-4d5688e7f971
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "701"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82027579-8216-4a06-ad8f-976f690e4f0d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1452"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2fc35cc8-77da-4802-a1bc-605c48d9328b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c070dad-c6d0-4402-962c-2b1eb1a5bad5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "651"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 32bc59d3-8a64-4309-9350-1750be90e593
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "653"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 546fc4e3-6402-4dcd-b204-e94294e04ab6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.177957Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dfcabc5-7d34-452d-9a5b-9ff4b0abe756
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a254698-3886-438d-889f-27de28f91538
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "701"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e487592-d162-4b41-b039-5572444c3475
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "653"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - acbec904-11d5-48c7-bb10-89d2167b5354
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1452"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d16b119-c514-41ca-8d0d-458a03741479
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ada6a6e1-0673-446e-8488-7aeeb899b35e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a72d4218-5d3d-4b54-93c1-cadd2c061899
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "651"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 149c2f1c-6d6e-4062-96f6-07e929aa3af6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.177957Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85a7a12a-229e-46c3-a089-7c4be9d9b365
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774237Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606860708Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "659"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
+      - Fri, 10 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d72227ee-7109-45a7-a114-d5638f1a5f23
+      - 4414dc09-8b42-4f4d-a7c4-7b8865ec7af4
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,19 +4376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "656"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
+      - Fri, 10 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 464a4004-c970-4e9b-baf6-815c1d778db2
+      - 8059c8d6-f264-4037-9567-588777418994
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,19 +4409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "656"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:20 GMT
+      - Fri, 10 Nov 2023 14:00:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bdfbc63-6033-47a5-99d0-f3d1fcab9ead
+      - 8594f127-7e8e-407d-afd2-8e63b025a72d
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,19 +4442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "656"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:25 GMT
+      - Fri, 10 Nov 2023 14:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4497,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c3eb8e2-eac1-4333-927c-2f7dd73066a2
+      - b4480d28-ec51-41b3-a0c9-9402b4419321
     status: 200 OK
     code: 200
     duration: ""
@@ -4508,19 +4475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "656"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:30 GMT
+      - Fri, 10 Nov 2023 14:00:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed2e7010-613c-4610-8bc7-ad1fbedec8ee
+      - ad2382dd-d4b3-4014-a219-39d8e72b8516
     status: 200 OK
     code: 200
     duration: ""
@@ -4541,43 +4508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "656"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4842e24a-1eb9-4589-b94d-65fd755cd039
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4586,7 +4520,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4596,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a28c7a03-6181-4fe6-ad03-fc06988d2b3e
+      - 56306c2e-5c4a-4f68-9f5f-8b7cbc898f15
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4607,19 +4541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +4563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b72f77f-e4a1-4f7a-8436-a1f7f4b79069
+      - 275d6764-5da3-4a82-8b22-d0c83edfa62a
     status: 200 OK
     code: 200
     duration: ""
@@ -4640,19 +4574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4662,7 +4596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 591bf0dd-55c7-4498-9fc0-0c7ab2a48092
+      - 13e7cfc8-6bec-43f2-8e3e-29b882a33563
     status: 200 OK
     code: 200
     duration: ""
@@ -4673,19 +4607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4695,7 +4629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18d91cef-8c21-49c1-b6a8-8a5e1fc5feba
+      - aedb6313-0a4f-4c6c-98ea-6c8cf57911a1
     status: 200 OK
     code: 200
     duration: ""
@@ -4706,19 +4640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2628"
+      - "2630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4728,7 +4662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 645e1764-f56b-4d53-8908-e5e11026be6b
+      - 8ddbf340-2486-4e33-a4f3-1e922f83aaff
     status: 200 OK
     code: 200
     duration: ""
@@ -4739,19 +4673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4761,7 +4695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7ce912c-8202-4665-9202-2a9650a587ad
+      - ee3f72e3-312d-4120-9e78-8925bc77fda0
     status: 200 OK
     code: 200
     duration: ""
@@ -4772,19 +4706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:16.235597Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:42.064169Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:41 GMT
+      - Fri, 10 Nov 2023 14:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4794,7 +4728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1d40f4c-5d50-45bc-8daf-5269d97656cc
+      - 76d82457-23bb-40f7-9289-b3d2a37cfb0e
     status: 200 OK
     code: 200
     duration: ""
@@ -4805,19 +4739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403142Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874123Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "657"
+      - "682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:42 GMT
+      - Fri, 10 Nov 2023 14:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4827,7 +4761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40cb3ee1-120b-4f0a-90cd-446dc25e3517
+      - 4add914e-20d8-4a70-ba0e-40e32b0ef8c6
     status: 200 OK
     code: 200
     duration: ""
@@ -4838,19 +4772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:42 GMT
+      - Fri, 10 Nov 2023 14:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4860,7 +4794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 663819c2-1ed4-4fa5-9b85-9db2561887ae
+      - 29bdbe93-eb7c-4c69-96d5-aad4cb834fa5
     status: 200 OK
     code: 200
     duration: ""
@@ -4871,19 +4805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:47 GMT
+      - Fri, 10 Nov 2023 14:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4893,7 +4827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba847540-0314-413e-a265-3077c5bd6c30
+      - 714d2fd6-7a7c-4334-a291-7ab49ab56a5c
     status: 200 OK
     code: 200
     duration: ""
@@ -4904,19 +4838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:52 GMT
+      - Fri, 10 Nov 2023 14:01:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4926,7 +4860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca7cd166-fbd3-4162-b649-b0087a320b2c
+      - 6fcb9e18-687a-4422-bbf9-6343e09a7742
     status: 200 OK
     code: 200
     duration: ""
@@ -4937,19 +4871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:57 GMT
+      - Fri, 10 Nov 2023 14:01:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4959,7 +4893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f4d6b6-9489-4a77-9cd3-f29c616dd461
+      - aa1be589-4962-4d03-b823-d23b2ff13949
     status: 200 OK
     code: 200
     duration: ""
@@ -4970,19 +4904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:02 GMT
+      - Fri, 10 Nov 2023 14:01:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4992,7 +4926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59728c21-473e-4238-b0cf-8ea80f29535d
+      - c81d4ae3-9653-4c86-bb6f-2e593ee4a6bf
     status: 200 OK
     code: 200
     duration: ""
@@ -5003,19 +4937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:08 GMT
+      - Fri, 10 Nov 2023 14:01:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5025,7 +4959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f3d1902-5981-4bc2-9661-fe2afdc2ec32
+      - fc6ccffb-efd8-40fc-bc23-cdf412a5160d
     status: 200 OK
     code: 200
     duration: ""
@@ -5036,19 +4970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:13 GMT
+      - Fri, 10 Nov 2023 14:01:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5058,7 +4992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a567e464-4eca-4a55-9293-8667103e6c35
+      - 9ba34b29-7f30-4127-acfd-0e9698ea5d55
     status: 200 OK
     code: 200
     duration: ""
@@ -5069,10 +5003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -5081,7 +5015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:18 GMT
+      - Fri, 10 Nov 2023 14:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5091,7 +5025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35c33335-1d64-41d4-9545-bd1d5b2a5c6d
+      - 428802b3-b475-4260-b318-472298675f53
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5102,19 +5036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852293Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171922548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:18 GMT
+      - Fri, 10 Nov 2023 14:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5124,7 +5058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc52d136-46bb-4f26-8dfe-402bde386973
+      - d931f037-4154-46c6-ae32-345c37d20ed2
     status: 200 OK
     code: 200
     duration: ""
@@ -5135,19 +5069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171923Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:18 GMT
+      - Fri, 10 Nov 2023 14:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +5091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a355dc3d-164a-462b-b674-d6d409a36ea3
+      - c1d87467-e23d-42e8-ab00-a4d4195828f4
     status: 200 OK
     code: 200
     duration: ""
@@ -5168,19 +5102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171923Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:23 GMT
+      - Fri, 10 Nov 2023 14:01:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5190,7 +5124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d758f41a-91b2-498f-900c-70d3e1998386
+      - f1ccd22f-e653-4c98-8420-9cd12adc266e
     status: 200 OK
     code: 200
     duration: ""
@@ -5201,10 +5135,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -5213,7 +5147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:28 GMT
+      - Fri, 10 Nov 2023 14:01:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5223,7 +5157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c706a60b-de7d-4a9d-8b0c-598f732908ef
+      - ea2363f1-d576-443b-9501-e87a281df09e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5234,10 +5168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -5246,7 +5180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:28 GMT
+      - Fri, 10 Nov 2023 14:01:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5256,7 +5190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c16e783d-d81d-4642-ba6f-60d9248ce220
+      - 7f04be90-796b-4ed9-9bce-fa10e873cdc0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5267,19 +5201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:28 GMT
+      - Fri, 10 Nov 2023 14:01:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5289,7 +5223,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd22f596-39ad-4853-af2d-0c68cad0d9ae
+      - 9cf2a2eb-4ed6-4270-946d-e3308dc85c03
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:01:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dc3b8c00-0544-4896-8724-a9cbfc469b8f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 14:01:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 296c407e-26d9-4ec0-8a98-89807e01b2b1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ec67b84-c7d8-4ce9-8ca4-075f204ebcbf
+      - 4a9232ba-7a1a-4f9b-b51c-41648639dbd0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-kubelet-args","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-kubelet-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "706"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:56 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e2a3072-7cf0-4cae-8d38-b62f7b7db6cf
+      - 14478ebd-97fc-44fc-8417-fbda0994e380
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "706"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:56 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 220cea02-1d14-4ded-9bf2-a01ff41cc53f
+      - 90e9a7c9-2832-4114-a10a-6b351319eb81
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588333967Z","created_at":"2023-11-07T15:49:56.588333967Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:56.604722327Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947290Z","created_at":"2023-11-10T13:23:54.823947290Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.901948315Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:56 GMT
+      - Fri, 10 Nov 2023 13:23:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef43c44-432e-4641-80a3-003169853f5a
+      - dceebdcc-60a1-467c-9335-185343e686b9
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:56.604722Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.901948Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:56 GMT
+      - Fri, 10 Nov 2023 13:23:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e80b604-bd71-4ffc-ae6c-2e5cb3611fc8
+      - 3b615e59-cf2c-4ff3-81d9-27083acf75af
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:01 GMT
+      - Fri, 10 Nov 2023 13:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c79007ba-3212-43f8-8551-c44c50022be9
+      - 7f780b04-67b8-413b-853e-18ba7c999c63
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:01 GMT
+      - Fri, 10 Nov 2023 13:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73d440f1-1a56-4b0e-94cb-9b69a73a01c6
+      - 83b21218-e352-460f-a3e2-7e86630f12ff
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2668"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:02 GMT
+      - Fri, 10 Nov 2023 13:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a021b4d-56aa-44c9-93c3-d44de2b3d90b
+      - 806cfbd0-8dfe-4d93-a74a-5c24066d2f63
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:02 GMT
+      - Fri, 10 Nov 2023 13:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90b2f86a-0f1e-495a-9807-e5301f907aa7
+      - c14f98d7-0c3c-45f0-9f2b-5192b1d256c0
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695427Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277483Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "682"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:03 GMT
+      - Fri, 10 Nov 2023 13:24:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67d2cb30-827c-442b-8894-5af29c375700
+      - 8f463266-aff1-453a-a9f5-435b12d6fe6e
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:24:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 913d664d-6060-43d0-9ade-1279ea3468b2
+      - fcacb2f6-da0f-4aaa-bcd1-7f71300c806b
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:24:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6621310-17bb-4619-a49f-43eff2d199a1
+      - b8bbffde-a868-451c-afb8-aa851e31cef9
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:24:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88905ce1-7815-47d0-bd2e-f11bd9e3e218
+      - b6eb19a8-6863-4b7c-b540-fcdc7bbf20bc
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a89c89e7-d2ba-4836-9179-4a3ba965951c
+      - 75ea1a33-9296-4954-9b76-80e761d458c5
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4a37098-2389-4c4c-bdff-a22c0a8dff88
+      - 79ce4521-eb64-41d1-a518-853d7e0d38ce
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24af6657-0022-4b8a-850f-0055eed9c753
+      - 0259738d-8c0b-4f28-bca8-45670fb26b80
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:35 GMT
+      - Fri, 10 Nov 2023 13:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 704e4a9a-b52f-4780-a075-3df59fec13e8
+      - 4903d676-b3b8-435e-91ac-247eed67a276
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:41 GMT
+      - Fri, 10 Nov 2023 13:24:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5281c84-64c9-4413-a5f1-81175882bf84
+      - 89301d4d-05e8-4a3e-907c-1bb8e2e2b338
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:24:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ea7e7dd-56e4-4ce7-8b32-6e798bdfdb6a
+      - 01684a68-c84f-4d83-9a88-867a110c1dac
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db3bbf99-76a3-489a-a038-838b51cf8594
+      - 53614c49-6320-4d2e-bde7-9b3fffeef63a
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:24:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37e8d218-7db6-4471-8388-9b8978fedd4f
+      - f47bea67-9e22-4ddf-a6b3-85f25ce33a2d
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:24:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06ddd1c2-c8da-45cf-9fb2-653bb2074e8a
+      - abeae860-79e5-42d6-9dd1-33af075bc0f1
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:25:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b765ee0-d3a1-430a-8531-a27304daffd8
+      - 07ebab75-47ff-48cc-9629-d6f5fe2c0219
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b575fb56-4fe6-46bb-bfab-85ba4b1fdae7
+      - 60e7fa51-ebb5-4acb-bbf7-a8a21851f6dc
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:25:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a59e9b2-0867-42ef-b486-0574755425fa
+      - 02ae5746-d30b-45af-b847-b8f1b4f7cefc
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:25:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4640c60-41f0-43a2-8d65-1faa1030558d
+      - ca741245-5c55-4287-b361-dabeb10cecda
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:25:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 448379af-82a0-4416-ad85-47a23727733a
+      - a7954829-d287-4945-abb7-7cc9dd6086b7
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52843c6d-ec44-4f15-8755-7ccdfc5fc35a
+      - 047650d8-d327-49b2-91bd-fbf5f455bee8
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:25:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe84fecb-7870-4c62-a38a-c45933c732d4
+      - d81add1a-8f01-49ea-bc22-b727eb9c594f
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:25:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a329c866-55d2-47a1-aeed-02b7ff89f3d4
+      - 8fe2b9b0-77c2-40b2-8a02-20552d97cba9
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:25:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4765d512-d9b2-496d-8b0f-f390acfb7c5f
+      - 5002072c-09eb-4748-97ac-95d5de7e92f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:25:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f3fe36-d408-4a20-b056-3278b24c7804
+      - 0b361579-40bf-4fdd-9ee4-b9fd32879553
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:25:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92608d9b-3255-423d-8b3e-fc87afa18a85
+      - 258c7bbd-46cc-424a-8e29-bd6bac531d0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:25:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 925c4099-c907-4c90-ac03-878054bc883a
+      - e1074a4a-4e0c-4abc-a77c-60eab3df32d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:06 GMT
+      - Fri, 10 Nov 2023 13:26:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0caff4d1-32af-4e73-a570-2b2961324488
+      - 3d8502db-20d0-432b-9533-9a855eb69eef
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:26:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a13cab13-3d12-44f9-8ec9-50d355618a6d
+      - f49a1963-2c68-4310-9b4d-2c85d5bdd2df
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:26:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7105c49a-fd6a-4238-985f-060eeb4bd701
+      - 93e8ad10-ea9e-4df5-8d55-335fced3dece
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:26:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcebca94-9985-442d-961d-442e4bafbb09
+      - 910ff7b6-ec8e-4671-9b3d-6f606b2c07ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:26:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33a992b3-0b15-449a-b72c-c7469b3a44b5
+      - 014705a7-db2a-4c74-a011-e69f7c6b7e30
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:26:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a062c63-930e-4983-b60d-ccc5ff2d6b5e
+      - b1b0c7e3-2c73-4f08-94b7-71a578ba3fcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:26:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9025bbc9-afcf-412e-bbae-4320005418e2
+      - 2b7f65ca-732a-4454-b95b-1ae41c97a60f
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:26:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6eee115-1770-4972-add7-58fd8c330c9b
+      - e63de832-31d6-436e-ac46-701683bcdd3b
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:26:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0654cc68-f2fe-405b-86cb-ebee010c8b99
+      - c234b284-a5f1-43ce-b75f-206b393756eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:26:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d0a4449-991f-4c3d-adfe-4e0dddf34a95
+      - fda69624-3f37-4c87-9c74-6eefc055b9a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:26:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95680048-fbc6-47b0-802d-e89f7f242ab3
+      - dab67778-c950-49b0-a95e-637c96a1dffb
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:26:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da89c9bf-d421-4a3e-85b0-22705511f0e3
+      - fafbc4f9-ad74-4e46-88b9-8b67e3512369
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:27:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9456fc05-343b-4d13-9db0-c05934dd0f64
+      - 6633cca8-3712-4fa9-91ad-0c1bcfff5012
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:27:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f370d16c-e007-4a8f-bb5d-abc5bcadc76e
+      - 8af1a69b-469d-42e8-802f-4724fba634f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:27:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74adadd0-604e-4fb1-8d38-bebcd79d8130
+      - b314135b-39c5-481b-abdf-43a4c8d3bda3
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:27:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fcb416a-66ec-437d-95af-2df2c816b855
+      - 37800fdc-c7aa-43af-8327-515bde517f92
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36f7911c-a793-42fd-98c1-60649c13678c
+      - f75b5e3d-a440-4b14-a253-e5ba5c4bc191
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:27:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdbd0397-1e3b-4472-ae3f-811bfe2b7dc9
+      - a5d4c069-922f-45ee-8399-538d20266fff
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:27:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2102d2e7-99a0-4c94-b4ef-4a9951be0793
+      - 0cf80818-6163-4ea5-892f-4d36e78df22d
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:27:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d20507a-4549-498c-8147-89c078dceb6b
+      - 975b1fbc-304a-47dd-9a26-9b4652bfc8fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:27:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3278fc00-849d-4a41-b76b-a385de4f21b1
+      - ef16c651-5809-4774-9956-d9add17cb933
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:27:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0900199-1f82-47ac-a0e9-5fcffe0d8ea8
+      - 261c4a79-5dab-4654-83df-aed24ff2041c
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db446e4d-7571-4462-8600-6f4c0cc1cb57
+      - 77e6a627-afbe-4701-bf9e-3a2c3f1792cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:27:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 568c13e3-5ec4-4e0b-8aa8-f72c0c17e755
+      - 98316ca8-7caa-4185-afff-5a5f380af762
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20756832-41c6-4866-b97f-8c0a954d92f5
+      - 162e5057-1b52-41ad-8095-82ff9793b2f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a256169-2c6b-4b9d-92da-93c285a63dea
+      - 3a2cbb2e-7a60-4784-bb24-d08735d44c3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:28:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40017f0c-685c-486f-bdc4-b3363da60de3
+      - 4769fcc8-5fad-440c-88ce-020148471d3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e1cc0e7-7a92-4837-8fc0-41a83ded40a8
+      - e6e07667-2957-48da-a360-417cb75d2ff5
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:28:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5c16cef-724f-46c3-9323-c0e8e3416859
+      - fc4cd018-2a12-48c1-bed3-670c7f5b82a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:33 GMT
+      - Fri, 10 Nov 2023 13:28:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c017cbfb-b5ef-4857-abbf-880b9127163e
+      - 71ecc817-e880-4057-a141-14682adad570
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:38 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34bcd051-35e9-4f82-8c88-c44e3a9d7c09
+      - 124629d0-346e-4126-8ccc-736a8ff49e8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "679"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:43 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c8196f9-d169-4389-bead-94d8d03e19c0
+      - aeaed230-1779-4d5c-9d96-c8e23e7976aa
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "679"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ee5a95a-777e-4f58-aafd-e5e18ad02a63
+      - a40bdcee-9d9a-42d8-bbe8-04e5cabcef18
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "679"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cf275e7-f5b0-4289-809b-3ab87eaa1eeb
+      - f26f246c-7b71-4181-9977-c17e3e76316f
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "677"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ffd69b6-69ba-433b-b349-d607c48b351a
+      - 732ffb94-8b02-4b2d-bfbe-6677af4d793e
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1462"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5c569c1-f9ef-4e74-883b-cfd1caa3f9f2
+      - b22ce951-ad9b-4035-bcd0-d144ee15fb47
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "677"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7836606f-975d-4cd0-99b7-aa2dc8fd577c
+      - e4c5f683-23a9-491e-a625-2a9373d7425f
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "641"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb6b3e10-66cf-4bea-8567-aae60ad565ed
+      - c5568f35-b238-43d4-af2f-a892c6236d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1462"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c2f41e0-1258-46a1-97a7-6980b5ebc50e
+      - abcb1685-6834-409c-ac72-d3aa9e7ca61d
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "677"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7afadba-8e2f-48ae-9b8f-74320c221abb
+      - d218d9d3-5cdf-4f49-9784-d1a21336166d
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "706"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74d7a251-30fe-4782-b809-543b49a24e7f
+      - 2d4f9e46-a9c4-42ab-89d3-ea01b1f5f3c6
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1462"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 818d4d71-6cb6-4487-a67e-c18d47e76346
+      - e213401b-9c77-4047-ad9a-4ab4db88ae90
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2668"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b75f9104-d20f-4a94-ae1c-6abd1f84b518
+      - 3fcd36b8-f790-4edf-9aed-a0b89f30d339
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "677"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca9affd9-9f57-4421-9091-9fda3ab8c79e
+      - 673f83a6-fc4b-4ad6-8a76-4443004e07d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:59 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c8f8fc9-1c72-48be-81d4-5d01326e9676
+      - 988ba9d3-3886-4d94-a5cf-f859c6a14666
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "706"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,139 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94c3a282-3c62-4ad4-bccb-bc9b1cafde7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78f602d8-0829-4e01-b8bf-d04ae7c6913b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2668"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71f0c535-dab9-4274-ac6c-36189e8e56d5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "677"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ddcac4db-ea11-4b98-902d-a44b33eeb958
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a4fe0ab-cbac-48cb-9e35-1611a7fd2f6a
+      - 9ce0b9ae-2d8e-4414-898e-6b39117e450a
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: PATCH
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090524988Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327170Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6ec95c4-463c-411a-bd3a-3b40a788ec1a
+      - d0d32a9b-67b1-4f5c-9f1f-7fe2c7d0f1d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "675"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ee88b40-b57d-4de5-ac0c-6a52ae3eeb12
+      - 4228d0e4-caf1-4a2a-b29b-13a2b3cd04df
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "675"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c34efe4-939d-4b82-acbe-05742b70bd24
+      - 582aa171-d0bf-4c40-b972-d2e89f03bb67
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8eb2017c-fa5b-477f-b878-d5f3706526b6
+      - 2f96485f-f7cb-45a5-933f-a7bb82f25164
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1462"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3953873-92ae-47df-b015-ef4bbd13bb67
+      - e465c439-d21e-413c-83a9-e194542e1ed5
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "675"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:01 GMT
+      - Fri, 10 Nov 2023 13:28:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9602d453-b372-4660-ac87-2924f4527cea
+      - 37b0d989-a9c9-404a-be09-8cdb4c11d095
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,10 +2858,175 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c4512c9-76a4-4b66-b280-cd976b632e0b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1507"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52892fe7-4ac5-43b6-9f46-7b90ae7f5a5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28642a61-3e26-4f15-9745-b42293ddbfcd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "700"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d40d8675-76c5-4249-a878-298365b87da9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:37.113612Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "687"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f86d94c1-daa2-468e-96ef-2fa3d0729799
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    method: DELETE
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "706"
@@ -3002,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:02 GMT
+      - Fri, 10 Nov 2023 13:28:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4533a2b7-4a9b-43c7-a308-f2e78f8bd475
+      - a3663377-8045-47ff-b933-50189e967d52
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1462"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:02 GMT
+      - Fri, 10 Nov 2023 13:28:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d297c0fa-d341-4913-aedb-785bdb5734a2
+      - affe5295-20f7-4cbc-b7e0-6c0e44a3e68c
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2668"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:02 GMT
+      - Fri, 10 Nov 2023 13:28:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 281418ce-98ae-4055-9698-dc0b1dd81d9d
+      - 606d5349-2192-478a-bfe3-7461bf9cb9c7
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "675"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:02 GMT
+      - Fri, 10 Nov 2023 13:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55597dae-afb1-43e5-a310-9496756e122b
+      - 1da96b34-4527-4d4a-a938-3d5d8326c3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:01.710400Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:02 GMT
+      - Fri, 10 Nov 2023 13:28:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a157643c-aa1b-453d-ab40-83f483d8b6a2
+      - dd53eba4-6ccf-4541-ac71-23b50d23e9e1
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,175 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: DELETE
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "681"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b47f4848-fbd9-40ea-b969-dfde1fd68825
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de577971-33de-4362-9ce0-51f67cb681ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17ec9805-6a61-452b-8ba3-1d7655c05154
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae6e7406-ef6c-4bb2-9984-db8d4e13b3bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c634c1b8-0710-4a9d-be34-e102535a46ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3332,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:23 GMT
+      - Fri, 10 Nov 2023 13:28:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f7790e-3a52-4278-972c-d860a739752d
+      - 0a225c3b-9204-453d-ab0c-0611c5419cbe
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3353,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450892805Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769034Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:23 GMT
+      - Fri, 10 Nov 2023 13:28:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5452c7a-52d1-48c6-b72b-aaef241158d3
+      - f86deced-2689-4fb5-a6ae-ac0b47fa4656
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450893Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:23 GMT
+      - Fri, 10 Nov 2023 13:28:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 383157e7-d3f5-4f65-9a7a-c70687563434
+      - 384e2b0d-d22e-452d-b99f-13725fe4dda9
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450893Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1465"
+      - "1510"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:28 GMT
+      - Fri, 10 Nov 2023 13:29:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c06fd81a-0b64-4442-8cea-a3e1c6fb26d1
+      - 4f9212f5-8415-4aab-9a46-882895c2dc04
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,10 +3320,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1510"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fac0a070-31c2-4661-af8f-f973c0347435
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3464,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:33 GMT
+      - Fri, 10 Nov 2023 13:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ee10323-e872-45cd-bc99-e98d6ef90cb5
+      - cc7d5db3-08e7-4a34-a66a-cf50b81bd56b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3485,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3497,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:33 GMT
+      - Fri, 10 Nov 2023 13:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaba96d0-1a87-4773-a298-b63e5136c4e7
+      - 624e0eb6-9644-4371-a29c-fce036acb5b0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3518,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:33 GMT
+      - Fri, 10 Nov 2023 13:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3441,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec348626-1f76-4f4d-857f-598f5e6c8df7
+      - ba668d8c-61fc-4551-a710-5fde0bf2bf09
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd0cda55-ba65-4d1e-8388-0c24aad4f906
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc1face7-9c34-4f4b-8863-4f4cbd1da091
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d29583a-90f3-463f-9b94-40532cfbc663
+      - 707d4a41-924d-4336-bcb5-777fe181af3d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -59,9 +59,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:50 GMT
+      - Fri, 10 Nov 2023 13:24:10 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 909dbbac-2890-4368-81f3-375c3e46c4dd
+      - acad753f-3867-49a9-b535-d035800100cd
     status: 201 Created
     code: 201
     duration: ""
@@ -82,10 +82,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
     method: GET
   response:
-    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -94,7 +94,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:50 GMT
+      - Fri, 10 Nov 2023 13:24:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -104,12 +104,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22d43c97-6e76-4f4d-bc8b-f0a5e3714598
+      - d8eb94aa-0919-4fd0-8885-c1e63cff631c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-placement-group","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -120,16 +120,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "709"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:24:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,7 +139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3bb4b9c-a654-4d1f-9af0-08102cf5dd19
+      - ef5a1b1f-648c-41ce-9457-dd77d924cfec
     status: 200 OK
     code: 200
     duration: ""
@@ -150,19 +150,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "709"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:24:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -172,12 +172,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fd1e803-f382-4bf1-b3f8-a9072baa5bbf
+      - ce56f192-6bec-4796-a8fd-fa07a0425c8f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b"}'
     form: {}
     headers:
       Content-Type:
@@ -188,16 +188,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.233834907Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402070557Z","created_at":"2023-11-10T13:24:13.402070557Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:13.412363565Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1525"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:24:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e276830-2704-44ea-8e27-c37fa6938170
+      - 70d93466-5049-4f5f-b2be-5d5689a4fbba
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.233835Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:13.412364Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:24:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68877933-17a9-45e8-91a1-39d3bdc281ac
+      - 0d9cb01e-8a8a-437b-9847-6f570d1779ce
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:24:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd1fd105-eb1a-4100-8070-b3c0b4716649
+      - d1f4028c-7bf5-486e-9ca4-048551807c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:24:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d782183f-ac1c-43f2-ac12-cf5985e35053
+      - 785322a6-b0a0-43a6-b5eb-b8ac4c6062a7
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2692"
+      - "2694"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:24:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa1ee2f4-ae71-4f36-b6fc-d8f453a6c04d
+      - 9c482e69-9dce-43f3-bb48-f4884a9fb0fa
     status: 200 OK
     code: 200
     duration: ""
@@ -350,19 +350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:24:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,12 +372,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 783fb2eb-a579-48b6-9e2e-bdd35eb511eb
+      - 866df43b-29ef-4809-b250-eaf9d29d0846
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -385,19 +385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769298890Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968699836Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:24:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d64ed5bc-93c0-416c-93de-026c56f92d5d
+      - 3519f0a6-e60b-4c14-990f-28ef5018eeee
     status: 200 OK
     code: 200
     duration: ""
@@ -418,19 +418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:24:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b68e1b77-035d-4138-a406-f34b8056a412
+      - 839e1be3-858c-40d2-9828-8d5c5eb9a869
     status: 200 OK
     code: 200
     duration: ""
@@ -451,19 +451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:24:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32c08c5c-5e9b-4d5a-8840-a9ce7ea5cbf8
+      - 4fa18620-ef60-4f01-b078-663ff0b69b20
     status: 200 OK
     code: 200
     duration: ""
@@ -484,19 +484,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:24:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af7dde9b-0f8b-4277-850a-8a6ab3570ad3
+      - dbfdd265-eee5-4790-a03a-ab678ee753f7
     status: 200 OK
     code: 200
     duration: ""
@@ -517,19 +517,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:24:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccfb2582-90b8-4ea3-b877-de759fb5072e
+      - 93b77503-6fb8-4993-8d8b-614d155547c1
     status: 200 OK
     code: 200
     duration: ""
@@ -550,19 +550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:24:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4624bdab-4ff2-4bba-add3-0433f8d91a1b
+      - d0834f2d-9f2f-4b45-8398-60c2f82fc631
     status: 200 OK
     code: 200
     duration: ""
@@ -583,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aec4354-309a-4fca-9437-06c1055be908
+      - e5d42bf9-9441-4e9f-b9cb-73d050f8803d
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:31 GMT
+      - Fri, 10 Nov 2023 13:24:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b5dd339-843e-4b98-9726-2d1c691c7fc2
+      - 1ae7d084-bcda-4def-8e14-5fca7e8cc547
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:36 GMT
+      - Fri, 10 Nov 2023 13:24:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5142c54-24b1-44bc-b49f-f9aa378497c3
+      - 8e2885bd-8f1c-4200-a6d1-3d76c15c705c
     status: 200 OK
     code: 200
     duration: ""
@@ -682,19 +682,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:41 GMT
+      - Fri, 10 Nov 2023 13:24:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7081c053-96d4-4eea-876a-98f723fe29f4
+      - b3b97ab9-0891-4b12-bfdc-22192ad68e66
     status: 200 OK
     code: 200
     duration: ""
@@ -715,19 +715,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:25:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b97145d-478e-44fe-87e9-2e949ddc6224
+      - 7f1798ed-8678-415f-a9d0-b9b85cdd3cca
     status: 200 OK
     code: 200
     duration: ""
@@ -748,19 +748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:25:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 347fc871-8fe9-4cf3-a3ed-e2d911f022ed
+      - 22709a7a-4edd-4ca9-8c92-107393f1eede
     status: 200 OK
     code: 200
     duration: ""
@@ -781,19 +781,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:25:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2686d1f1-a55c-4c8f-b616-76ab054d2d3c
+      - af10567a-8762-4fe1-b951-c399d6b3f9ab
     status: 200 OK
     code: 200
     duration: ""
@@ -814,19 +814,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:25:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 135f9e56-a251-421b-80e9-f5639407282f
+      - 9c27c904-68e6-4109-b2c1-06402f5e3203
     status: 200 OK
     code: 200
     duration: ""
@@ -847,19 +847,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2b5675e-8528-4af7-b583-cc294a2a7644
+      - f1115b16-8678-4da2-b00e-ae0a4ef4d1ca
     status: 200 OK
     code: 200
     duration: ""
@@ -880,19 +880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:25:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b3ad3ee-b549-4ed9-a167-6642ddd66b55
+      - d81367f9-b97f-45ab-b5cb-4adff46c64ba
     status: 200 OK
     code: 200
     duration: ""
@@ -913,19 +913,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:25:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 975ba53c-32da-42ca-b9bb-288998068b35
+      - 2c267261-ee20-4be4-a15b-5633b2e24474
     status: 200 OK
     code: 200
     duration: ""
@@ -946,19 +946,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:25:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93c21a9d-a6f1-4371-ba81-ded9d62a38ed
+      - 856d76ac-3058-4416-a44f-1240d4591cc2
     status: 200 OK
     code: 200
     duration: ""
@@ -979,19 +979,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:25:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 400c113d-4bee-4132-87e4-779daeb082aa
+      - ef135f05-4c21-4852-999d-b25d86bd6396
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,19 +1012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:25:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8499e719-88a4-4cd5-8416-4f6822d4044b
+      - 12b38643-1872-492f-81ba-5f8607682715
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,19 +1045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:25:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f8dc54f-519d-4566-8d42-4ce5cf78e103
+      - ec18b224-0b97-437c-aa49-ac153f602305
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,19 +1078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cec82eef-b66c-4145-bd75-03eae9483f22
+      - f373b518-f221-4a11-a754-02c6fab217e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,19 +1111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:26:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d535e71-5363-4761-8514-2f2db9863d3e
+      - 0fd774fd-aa1a-484b-acc5-fe5ad916d7da
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,19 +1144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:26:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e068854-9036-4303-8cea-cb0b315360b3
+      - 92bf773d-c7c6-4a59-958e-a6d4a3dd32e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,19 +1177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:57 GMT
+      - Fri, 10 Nov 2023 13:26:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ad41008-2941-4115-9701-a198c2327c4e
+      - a118094f-c7eb-4bc9-933e-6431713304f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,19 +1210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:02 GMT
+      - Fri, 10 Nov 2023 13:26:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac3518bc-666e-4308-8118-df9651a0a783
+      - b5ade3b8-482e-43b6-828c-bf7eca02210f
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,19 +1243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:07 GMT
+      - Fri, 10 Nov 2023 13:26:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8af724ec-e611-42fa-b5be-d83d9735d3ac
+      - 903c9e13-2d46-41c1-922b-b46c86a06094
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,19 +1276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:26:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2585dd3-0a55-464c-a4bb-776c0ef6fe1a
+      - bb1d17b1-24bb-40c6-9277-7ba4aabf0b0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,19 +1309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:26:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8be3f6a-a3cf-4597-a81b-a24510b104d7
+      - a888a66e-1659-454b-ab34-3edfa04ec358
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,19 +1342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:26:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - add77047-8d62-40b0-a0d7-334af28df35d
+      - ab7b3f38-1ec2-4fb6-9d13-8e0bc5b975a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,19 +1375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68e8f8dd-d9a2-40bb-a0b8-c4c33a2e742a
+      - b27efe76-f043-4474-b620-220c635f2e81
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,19 +1408,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:26:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17ab00db-9073-4134-97bf-907f9d773e8e
+      - 6621b971-47eb-4b71-a4f3-b3e6a5501a2a
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,19 +1441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:26:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9758897-0b09-413a-88ab-6590e719954c
+      - 2df36f35-54c7-4308-8bdf-5bf19a56b83a
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,19 +1474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:27:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf559a21-15c2-48fd-af49-9d211b5b8ccd
+      - be2bb69e-6ca4-4a1b-98c5-289b2c3b4e19
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,19 +1507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:27:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 963d0d6b-e1ee-48dd-90cc-30d2e8faf37f
+      - 831f7951-eb45-4fa3-8c7f-fb0fdbaef2d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,19 +1540,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:27:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eb843e4-9f2f-46a6-9c1d-d33c721d5878
+      - 358ee1fc-90da-45b0-ac2c-ca288688831e
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,19 +1573,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:27:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46733cdf-b3b4-4449-9751-445c3424365a
+      - 02703413-91f1-46d8-842a-6c251ed56aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,19 +1606,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:27:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24d10c8a-4c4b-469d-aea0-383fdf8084d9
+      - d10e0dd6-8841-41a2-afdf-7a22d81ab819
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,19 +1639,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:27:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ea193e5-b60f-4697-b143-7cf2825ae877
+      - 4b49201f-726b-41fd-8438-09818f86d880
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,19 +1672,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:27:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75556ea2-4ddb-40a8-8cd1-1557b8b6695f
+      - f25effed-0233-43e6-b0ff-b4f08df10513
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,19 +1705,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:27:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f998b99-baf1-4c39-b151-26f9c9164818
+      - 8453a396-00ca-4736-801a-5552b4353b86
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,19 +1738,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:27:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20e82ce8-6086-4d10-baa8-4b5f72cb24b8
+      - 21f10121-55f2-4152-afeb-f1294d846ee9
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1771,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:27:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db8bbd22-c8b3-4b14-b9d2-3f628076a32e
+      - 355071b8-7445-4620-972f-884140786a70
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,19 +1804,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:33 GMT
+      - Fri, 10 Nov 2023 13:27:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caebbc49-044c-428b-9ff3-fd83f47cc593
+      - 38439422-5bab-44ec-9fde-bbf432a7691a
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,19 +1837,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:38 GMT
+      - Fri, 10 Nov 2023 13:27:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db836bd7-9fd4-4b62-96e1-dc6883267043
+      - 24cb6a5c-a859-455c-9511-17e832e81182
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,19 +1870,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:43 GMT
+      - Fri, 10 Nov 2023 13:28:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8b4047f-4034-4413-a37d-b6efbcafd253
+      - 8687a844-5c35-427a-bf7d-f9829d03d107
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,19 +1903,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:28:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb381e09-9557-446b-b993-4a4dc2658d79
+      - 76c82573-1e9b-44be-adf6-5bd8782368fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,19 +1936,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 473d12dd-f3ab-4a85-9335-79654f4dfb56
+      - fa5a29d8-3e06-4057-a6c8-cfa2ea8e2814
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,19 +1969,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:28:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d288a72-6ffa-4bfd-90a7-d91994c5f777
+      - a54676f2-2cfd-4219-9800-1cb1bd63f9d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,19 +2002,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:28:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e9a9d96-fc4a-475f-a04a-62284692161c
+      - 30d8a3e6-cdcc-4f60-a561-ee1fe687ce12
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:28:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1183fbc-f6ef-4bb0-a37e-fdebc1c932f2
+      - fd6a8ba4-e591-49f7-a787-9d1bee195e95
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:28:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 595b3cdc-def4-4e4a-bfe1-c3c8e1bc5827
+      - cfe330dc-4a42-43ba-a407-63f1ff66aeff
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:28:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87538950-660d-4ad3-853f-eb2402484c7e
+      - 3acb6033-9201-4951-a550-7b30e91fe201
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712603f8-84e3-45cd-81f3-e23e4235ffe7
+      - 327e9135-083b-4588-ad60-2814ecae9d17
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37944384-25f3-48f7-871a-e484d97649e8
+      - d8cd6ee6-28c1-402b-bf88-281b0e2e847b
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:33 GMT
+      - Fri, 10 Nov 2023 13:28:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8af3e28c-87a3-4b38-84f6-d2088dca5238
+      - 15b01fa4-46f7-4fe4-8af0-8379476a452f
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:38 GMT
+      - Fri, 10 Nov 2023 13:28:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a252cc1a-41ab-4390-aa69-69fb9d7308b0
+      - 157e6397-f879-44f3-982b-2ac5349abac3
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:43 GMT
+      - Fri, 10 Nov 2023 13:29:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 507d3d75-2613-40c5-b5e5-c87686b05e34
+      - cffc88ba-273e-45c3-b80d-f70878322200
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "646"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:29:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f688ba19-5b51-43f5-99b0-be84f5a84850
+      - 87018a01-96e5-4058-9fef-1555d50db7e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1468"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:29:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d388300-a6e2-4591-a8e5-e36256c08ccd
+      - dad54234-4785-4b9c-af5c-c3f4581b8c29
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "646"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de4cbec2-c748-40f5-bc8d-a170251497f2
+      - ca0f2947-96b9-4310-9250-9cc26eeae198
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "643"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20b208f7-0005-4ca3-b12c-4c8b887d944e
+      - f2022309-ec72-41ca-a80d-29befa49c6eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1468"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aefe5325-44dd-47db-9952-c6de22935ec8
+      - 419a9f92-43a5-4ada-9dc1-a478f711780f
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "646"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 094f7219-826f-459d-9667-c03900fece7b
+      - 89edc1bf-8525-4b1e-8680-2555a63e0fb7
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,19 +2497,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "709"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bc98853-885e-46a7-ad2b-13cdb0353df5
+      - 28ce8f16-5ddf-4d39-860f-7efba4bf09b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,10 +2530,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1e0b04a-c761-474f-83e0-cc4386b01e5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a3781d8-343b-47f0-9f2e-777e4971a325
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -2542,7 +2608,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62d9a6b8-8fe5-4cdc-854d-81efd0b51678
+      - a6f634f9-cda8-4fab-8527-39042e3c41d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,19 +2629,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:49 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 469aa9dd-cee4-44ca-95ca-b7d21da07557
+      - e07ac8a9-2a70-40ce-b500-3a6a5a52d0e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,19 +2662,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2692"
+      - "2694"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:51 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64ee0639-c425-4cc3-9cb8-e007381bd15b
+      - 155e566e-fd30-4d4a-aa33-1b76f45b792c
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "646"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:51 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c612f033-64b0-4d79-8cfa-5890d55be66c
+      - e7fb8c3e-b485-4f7d-b0ad-2c178c993e3e
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:51 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 243e4b2c-f1dc-4b91-9d1f-1e907535f7d0
+      - 135f9a39-c70a-44f7-9295-c9b36bfde90d
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,19 +2761,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "709"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7200ae92-0915-425b-bf54-5ec3873fb102
+      - f816486e-3387-4996-ba6f-4d8133d3a478
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,19 +2794,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1468"
+      - "669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 592604d6-c802-4122-a1f0-3a5ec73cc2de
+      - e0f20f30-2796-4ecb-b66e-b60b90cf8107
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,19 +2827,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "646"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db35e323-883b-4cf2-a7a1-fa7ec83ccee3
+      - 85b5ba51-313b-47aa-96dc-33319d04c7bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,10 +2860,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
     method: GET
   response:
-    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e36331e3-8f88-4a35-9774-82e0af50e22b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -2806,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c243216-639b-4cc0-8533-3c4a35384e3e
+      - 03fc1581-01e1-45af-9944-88160ed2d20e
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,19 +2926,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "643"
+      - "2694"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2849,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95e484b-bae4-4986-8889-17ca5680e87c
+      - 2449aae7-571f-40ec-88e3-85e3f14e4f43
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,52 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:54:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a817cdf-61d6-49bb-9974-35d01951447c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101106Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405553554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "652"
+      - "675"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:29:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b51d0631-db53-4684-b3e1-128b409d40e9
+      - 10fbe3db-6375-4b7f-958f-6eda2673cae2
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,19 +2992,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "649"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:29:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 717ac99e-29a8-4e15-907f-c35b03fb5a22
+      - e996dfce-5785-49f1-bb34-5dc271d7c94c
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,19 +3025,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "649"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:29:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95be636b-ec72-4a86-94ec-9d4c18b807dd
+      - abdcef00-c8b9-4d74-9c06-59aea269e05c
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,19 +3058,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "649"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:03 GMT
+      - Fri, 10 Nov 2023 13:29:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7db6b678-479d-43fa-bbca-8ac056f105d2
+      - 56df17c1-05b9-4711-b914-1052ba2090f0
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,19 +3091,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "649"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:08 GMT
+      - Fri, 10 Nov 2023 13:29:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 732c992b-2566-49bc-8eb6-bf359637d07e
+      - fcfb6f48-7856-47f5-a9e1-68bcf581a348
     status: 200 OK
     code: 200
     duration: ""
@@ -3058,10 +3124,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"f563d778-6543-42b7-bc3a-087d590a5137","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"5b83fc02-791d-409e-9a6a-617f693efb13","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3070,7 +3136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:29:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3080,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bec5bfe-0894-48bc-952d-a089ce20bd72
+      - b534fda4-7d19-4722-8eab-71b22da72984
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3091,19 +3157,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825727679Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716342601Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:29:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3113,7 +3179,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c12f931-9381-4006-a372-dc4a05299097
+      - 8fd159d5-6971-4731-af7b-fd88903b5d95
     status: 200 OK
     code: 200
     duration: ""
@@ -3124,7 +3190,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
     method: DELETE
   response:
     body: ""
@@ -3132,7 +3198,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:29:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3142,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 866ee651-b7ca-4689-bf6e-d143f08d1008
+      - 5f781a7e-016a-4596-982a-03294a86a4a7
     status: 204 No Content
     code: 204
     duration: ""
@@ -3153,19 +3219,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:29:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3175,12 +3241,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b13f4233-7a9b-47c5-ab52-95072f711980
+      - bd54f8e7-d5ea-464a-9b4c-a4e0f7ca27dd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -3191,7 +3257,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3200,9 +3266,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:14 GMT
+      - Fri, 10 Nov 2023 13:29:43 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3212,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b5a5429-eb02-432d-926c-4268ecc861a0
+      - 561ee323-31e0-421f-9e54-60d6ae5e1347
     status: 201 Created
     code: 201
     duration: ""
@@ -3223,10 +3289,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
     method: GET
   response:
-    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3235,7 +3301,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:14 GMT
+      - Fri, 10 Nov 2023 13:29:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf5682fe-4eea-405c-b0a0-a8dd57b3b705
+      - 271073b9-3ac3-4235-82dc-6cf2088d7db9
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,19 +3322,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:18 GMT
+      - Fri, 10 Nov 2023 13:29:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3344,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a78b211a-ae38-4734-860b-7fd616fcc610
+      - ca71a988-871d-41bb-963e-9f588f7da3d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,19 +3355,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:29:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +3377,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1d71eb6-6e20-4601-856d-ddf7cf2507a8
+      - 6578fc66-9560-453e-9209-43b1e08cb9a2
     status: 200 OK
     code: 200
     duration: ""
@@ -3322,43 +3388,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a560a082-1a73-4dfa-86b9-4d4644bfc81c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e1597660-f994-438f-aa99-a42c65f010a5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"50d8e763-233f-474b-a145-0462e885450e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3367,7 +3400,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:34 GMT
+      - Fri, 10 Nov 2023 13:29:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3377,7 +3410,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dbd8869-04d7-405f-af91-c96ab364e0c5
+      - 2e9410c3-cb3b-46ea-a081-a730646fd73c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3388,10 +3421,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"d539826f-786f-4091-98fd-69d345ea1be0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3400,7 +3433,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:34 GMT
+      - Fri, 10 Nov 2023 13:29:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,12 +3443,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a9a48d7-8dc7-4375-9a8c-acf82b79822c
+      - 92d3a056-cc26-4c90-9cde-d48e59307ade
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-placement-group","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -3426,16 +3459,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "709"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:35 GMT
+      - Fri, 10 Nov 2023 13:29:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3445,7 +3478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0329a7f0-92cb-4f82-8b68-655bd3399974
+      - 5cab7193-17a4-4d47-9e18-deba1d5bb672
     status: 200 OK
     code: 200
     duration: ""
@@ -3456,19 +3489,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "709"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:35 GMT
+      - Fri, 10 Nov 2023 13:29:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3478,12 +3511,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8910aab1-13c5-4205-bd42-fa2e778f3005
+      - 712121c0-2307-471a-a13b-1bf84281872c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4"}'
     form: {}
     headers:
       Content-Type:
@@ -3494,16 +3527,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886773868Z","created_at":"2023-11-07T15:55:35.886773868Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:35.906055566Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644092Z","created_at":"2023-11-10T13:29:57.173644092Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:57.190218001Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:35 GMT
+      - Fri, 10 Nov 2023 13:29:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3513,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 217be422-d2b5-4dda-b31c-802b5a896863
+      - d97e7ab2-daf0-462a-a23e-89939697b175
     status: 200 OK
     code: 200
     duration: ""
@@ -3524,19 +3557,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:35.906056Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:57.190218Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:36 GMT
+      - Fri, 10 Nov 2023 13:29:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4174c4c1-af50-4e99-8748-1e731dee2215
+      - e1b6b7b7-726b-4c16-a309-e5027d8138aa
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,19 +3590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:41 GMT
+      - Fri, 10 Nov 2023 13:30:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e807b94a-6499-4738-a171-5711b26627b7
+      - d909900f-d87c-46fd-a276-98a6b46c6b3a
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,19 +3623,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:41 GMT
+      - Fri, 10 Nov 2023 13:30:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3612,7 +3645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6add2c-259d-4c45-95d3-aa7bf3dac6eb
+      - 461d7187-1a6f-4c38-9859-55401c8649f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,19 +3656,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:41 GMT
+      - Fri, 10 Nov 2023 13:30:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +3678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc33b355-0d2d-4238-b87a-ee0bcc7519cd
+      - 75115334-ba6e-4c0a-932d-0e550af463a1
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,19 +3689,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:41 GMT
+      - Fri, 10 Nov 2023 13:30:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,12 +3711,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff26d866-62eb-4428-8a27-a97368ddbd41
+      - 80bdde33-7d06-4127-95fb-595fac9b1d33
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -3691,19 +3724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/pools
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186326Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407074Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "653"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:42 GMT
+      - Fri, 10 Nov 2023 13:30:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3713,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6197d28e-8f21-4be6-bb62-0e86eac9d9ea
+      - c7b6d252-c301-4609-a616-7c599ee284ba
     status: 200 OK
     code: 200
     duration: ""
@@ -3724,19 +3757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:42 GMT
+      - Fri, 10 Nov 2023 13:30:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3746,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47438e42-3b76-4dc7-a779-d4decb0d0527
+      - ccbb99a5-2f0e-44d8-92e9-960280af3181
     status: 200 OK
     code: 200
     duration: ""
@@ -3757,19 +3790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:47 GMT
+      - Fri, 10 Nov 2023 13:30:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3779,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a81136b2-4134-4f83-9c65-0f85089ea66d
+      - 846e54e3-8a01-4d1b-b4ea-202a2da6322b
     status: 200 OK
     code: 200
     duration: ""
@@ -3790,19 +3823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:52 GMT
+      - Fri, 10 Nov 2023 13:30:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3812,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad47c972-8415-40b4-81a7-0f6026f62ad0
+      - 8a0976c5-5134-47b6-9cf8-8979a2d580e7
     status: 200 OK
     code: 200
     duration: ""
@@ -3823,19 +3856,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:57 GMT
+      - Fri, 10 Nov 2023 13:30:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3845,7 +3878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c31460d-d4a1-41b2-a26b-ab742399be25
+      - 9ac69533-3573-4176-80d7-07197b3b156a
     status: 200 OK
     code: 200
     duration: ""
@@ -3856,19 +3889,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:02 GMT
+      - Fri, 10 Nov 2023 13:30:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd8badc-2648-48d2-9c18-85b08abe78d3
+      - 2de6d299-6cbe-485c-b577-df9af27b7094
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,19 +3922,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:07 GMT
+      - Fri, 10 Nov 2023 13:30:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3911,7 +3944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb3ae7b4-1450-4309-989a-757eb119a884
+      - 4dc3ac25-2f99-4e7c-b0b1-42f8a1fc4017
     status: 200 OK
     code: 200
     duration: ""
@@ -3922,19 +3955,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:12 GMT
+      - Fri, 10 Nov 2023 13:30:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3944,7 +3977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89a95d54-60dc-4b46-bb4b-b9e4de554a51
+      - c33728c2-6c66-43db-857a-1a257f6f16dc
     status: 200 OK
     code: 200
     duration: ""
@@ -3955,19 +3988,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:17 GMT
+      - Fri, 10 Nov 2023 13:30:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3977,7 +4010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8125eff1-8dd4-403a-8293-44e0a7263149
+      - edd6423c-38c7-4961-a344-e3c1bad1d96c
     status: 200 OK
     code: 200
     duration: ""
@@ -3988,19 +4021,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:22 GMT
+      - Fri, 10 Nov 2023 13:30:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4010,7 +4043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 135b4bb6-22e8-4cc8-ab02-dd007ab2bf81
+      - 1a4e9bd1-6de7-4c28-8a0f-be2ee947d006
     status: 200 OK
     code: 200
     duration: ""
@@ -4021,19 +4054,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:27 GMT
+      - Fri, 10 Nov 2023 13:30:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4043,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40bd432e-a705-46d9-b8bd-537b4f5aec09
+      - 36fa36c7-df3c-48c7-a30f-f20c38833531
     status: 200 OK
     code: 200
     duration: ""
@@ -4054,19 +4087,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:32 GMT
+      - Fri, 10 Nov 2023 13:30:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4076,7 +4109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c15d3251-2666-4595-984b-944dfff1afdf
+      - 1d05748f-59b2-4bfa-be08-f37ef7fb1466
     status: 200 OK
     code: 200
     duration: ""
@@ -4087,19 +4120,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:37 GMT
+      - Fri, 10 Nov 2023 13:30:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4109,7 +4142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24a588d5-9e73-49f3-b3dd-7bb17f5fa35b
+      - 321e6c19-1900-4921-a61e-cdeec85ac1a0
     status: 200 OK
     code: 200
     duration: ""
@@ -4120,19 +4153,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:43 GMT
+      - Fri, 10 Nov 2023 13:31:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4142,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35994b64-b9e8-4e0e-bcde-e57a8ab55f66
+      - b2684321-e68e-4d74-8525-cda67f382247
     status: 200 OK
     code: 200
     duration: ""
@@ -4153,19 +4186,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:48 GMT
+      - Fri, 10 Nov 2023 13:31:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4175,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc239222-b285-4148-99ba-6735c481983a
+      - 75e85bcc-db69-4c5d-9cef-33ec235b264a
     status: 200 OK
     code: 200
     duration: ""
@@ -4186,19 +4219,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:53 GMT
+      - Fri, 10 Nov 2023 13:31:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4208,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67d691d9-e4c5-4126-9d70-dd60f59807c1
+      - 7c2f2bc1-5f49-43ae-b6da-6e9757196e0c
     status: 200 OK
     code: 200
     duration: ""
@@ -4219,19 +4252,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:31:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4241,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1977125-9a49-4fe8-b998-7549e18295b2
+      - 06e7a906-f687-4da4-85af-8fc86d22fe4a
     status: 200 OK
     code: 200
     duration: ""
@@ -4252,19 +4285,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:03 GMT
+      - Fri, 10 Nov 2023 13:31:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4274,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a1bb7d9-ae42-46b3-9b9a-784cb090639f
+      - 436422ed-65d9-4ab6-a86a-893508613d65
     status: 200 OK
     code: 200
     duration: ""
@@ -4285,19 +4318,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:08 GMT
+      - Fri, 10 Nov 2023 13:31:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4307,7 +4340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8de09beb-c454-456b-9ec9-58cc77af0600
+      - 173e81bd-62fa-4e23-b66b-06bb92a3e357
     status: 200 OK
     code: 200
     duration: ""
@@ -4318,19 +4351,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:13 GMT
+      - Fri, 10 Nov 2023 13:31:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4340,7 +4373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5595202a-dcd3-4f2c-b44e-55b3fbbba8e6
+      - 8d1a2456-8c36-4dfe-9f81-a2abf654e3cf
     status: 200 OK
     code: 200
     duration: ""
@@ -4351,19 +4384,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:18 GMT
+      - Fri, 10 Nov 2023 13:31:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4373,7 +4406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab1776e9-daea-450f-adc3-e458e3bcdbb3
+      - 89391b66-c643-4c42-b6c2-a0ddc5384f15
     status: 200 OK
     code: 200
     duration: ""
@@ -4384,19 +4417,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:23 GMT
+      - Fri, 10 Nov 2023 13:31:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4406,7 +4439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b89963b-3134-44be-a216-653ed5baeb2e
+      - 133fc4d5-e8a2-4d82-9359-14d01396588b
     status: 200 OK
     code: 200
     duration: ""
@@ -4417,19 +4450,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:28 GMT
+      - Fri, 10 Nov 2023 13:31:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4439,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb3022a6-17a4-4092-bb09-ce4b2a4284a2
+      - 6eb31ff8-52f6-4228-8ddb-bc4b13267ef9
     status: 200 OK
     code: 200
     duration: ""
@@ -4450,19 +4483,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:33 GMT
+      - Fri, 10 Nov 2023 13:32:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4472,7 +4505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 429a04a1-ac1c-414a-ab07-29ecb7b5c39e
+      - 486b22ca-256e-4d44-9243-43d0d4ba0e10
     status: 200 OK
     code: 200
     duration: ""
@@ -4483,19 +4516,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:38 GMT
+      - Fri, 10 Nov 2023 13:32:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4505,7 +4538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76eeec04-f86f-4d18-a999-160f60feaf5d
+      - a9201c82-a5a4-49f6-971d-303d00154143
     status: 200 OK
     code: 200
     duration: ""
@@ -4516,19 +4549,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:43 GMT
+      - Fri, 10 Nov 2023 13:32:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4538,7 +4571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ffc9a23-a61c-44e8-8130-adecbc8eb98a
+      - 2c040b68-6901-437d-8a61-77a6f91dba49
     status: 200 OK
     code: 200
     duration: ""
@@ -4549,19 +4582,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:48 GMT
+      - Fri, 10 Nov 2023 13:32:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4571,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93cc2e87-f43c-4991-9bf6-2cd19a05346b
+      - 6f31be28-f26a-4b98-97a4-f3aef013a176
     status: 200 OK
     code: 200
     duration: ""
@@ -4582,19 +4615,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:54 GMT
+      - Fri, 10 Nov 2023 13:32:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4604,7 +4637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8124fe6b-0e8f-47be-aee8-88b9f21bf0d0
+      - 2a7cd21a-8d7a-4e32-8c4f-5cb51543ac21
     status: 200 OK
     code: 200
     duration: ""
@@ -4615,19 +4648,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:59 GMT
+      - Fri, 10 Nov 2023 13:32:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4637,7 +4670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97403502-c517-4d62-b808-81bbea8bdb72
+      - ea3a0f76-7e5d-4389-bac4-a58f8bd9887f
     status: 200 OK
     code: 200
     duration: ""
@@ -4648,19 +4681,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:04 GMT
+      - Fri, 10 Nov 2023 13:32:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4670,7 +4703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0628ff3d-7811-4cdc-a083-296ff9ff62ac
+      - b21f6a54-0c5a-4953-ab04-ad8238fcb0dd
     status: 200 OK
     code: 200
     duration: ""
@@ -4681,19 +4714,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:09 GMT
+      - Fri, 10 Nov 2023 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4703,7 +4736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 314a8ff6-a104-4b74-b05b-35792b4257ea
+      - d2ee2987-ba3e-4ad1-9f13-b868a6cabc93
     status: 200 OK
     code: 200
     duration: ""
@@ -4714,19 +4747,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:14 GMT
+      - Fri, 10 Nov 2023 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4736,7 +4769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0cb1fef-14db-4fde-aaa5-18ea6eecf141
+      - 72e7a2cc-d48f-42d7-aa24-d535c632f444
     status: 200 OK
     code: 200
     duration: ""
@@ -4747,19 +4780,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:19 GMT
+      - Fri, 10 Nov 2023 13:33:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4769,7 +4802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aecf73f-19aa-4f9b-aca6-0be30729ff55
+      - c91ed368-9fbd-4896-9764-eb0f6c113298
     status: 200 OK
     code: 200
     duration: ""
@@ -4780,19 +4813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:24 GMT
+      - Fri, 10 Nov 2023 13:33:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4802,7 +4835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19958ca7-096a-4e87-b1b6-7408202ab1c3
+      - 95b7b760-d13b-4759-9fa8-ef02faa982c7
     status: 200 OK
     code: 200
     duration: ""
@@ -4813,19 +4846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:29 GMT
+      - Fri, 10 Nov 2023 13:33:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4835,7 +4868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9033fb7-195a-459b-9143-602a163953c8
+      - ec6af4c7-a68a-4d9b-ad7d-42fd5640b7c6
     status: 200 OK
     code: 200
     duration: ""
@@ -4846,19 +4879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:34 GMT
+      - Fri, 10 Nov 2023 13:33:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4868,7 +4901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d930c10f-ed6c-42a1-8bba-3a182b56abe6
+      - 0e8a2674-013e-43a4-9e80-5bcc50377017
     status: 200 OK
     code: 200
     duration: ""
@@ -4879,19 +4912,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:39 GMT
+      - Fri, 10 Nov 2023 13:33:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4901,7 +4934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e6f3441-a54a-4ce4-a867-73445b21b68f
+      - b052fe47-f52b-408b-9dde-806d1473e6c0
     status: 200 OK
     code: 200
     duration: ""
@@ -4912,19 +4945,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:44 GMT
+      - Fri, 10 Nov 2023 13:33:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4934,7 +4967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e927fc-a7a6-491d-9567-39b9d46ca537
+      - 3b6d6f4e-8484-491e-b260-d009d13c4a30
     status: 200 OK
     code: 200
     duration: ""
@@ -4945,19 +4978,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:50 GMT
+      - Fri, 10 Nov 2023 13:33:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4967,7 +5000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3673598-88b0-4e2c-a765-9ef29f276576
+      - bea2adeb-6b38-4107-bd5e-ba35fadb0523
     status: 200 OK
     code: 200
     duration: ""
@@ -4978,19 +5011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:55 GMT
+      - Fri, 10 Nov 2023 13:33:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5000,7 +5033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4062db-986e-49b0-b9ef-e7e947e2b038
+      - 39a871ae-0baf-441b-bec1-667f42c5dcb9
     status: 200 OK
     code: 200
     duration: ""
@@ -5011,19 +5044,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:00 GMT
+      - Fri, 10 Nov 2023 13:33:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5033,7 +5066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1fe3f20-b9db-4802-9bd5-17d61fe1607d
+      - 25319739-943c-463b-9d95-965bf86c6643
     status: 200 OK
     code: 200
     duration: ""
@@ -5044,19 +5077,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:05 GMT
+      - Fri, 10 Nov 2023 13:33:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5066,7 +5099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0262e0b4-45b6-494d-8a49-74639083f933
+      - 08f6712c-e74b-4736-8181-04484c54aae9
     status: 200 OK
     code: 200
     duration: ""
@@ -5077,19 +5110,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:10 GMT
+      - Fri, 10 Nov 2023 13:34:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5099,7 +5132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a7e0f87-0434-4a46-b27e-402ac223eef4
+      - 9a26d62f-70fa-4939-8019-702179b994d7
     status: 200 OK
     code: 200
     duration: ""
@@ -5110,19 +5143,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:15 GMT
+      - Fri, 10 Nov 2023 13:34:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5132,7 +5165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95155b82-c208-4793-b0dd-edd1c7bc37e4
+      - 16c0e795-46ab-4b64-ba25-783f49e9edcd
     status: 200 OK
     code: 200
     duration: ""
@@ -5143,19 +5176,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:20 GMT
+      - Fri, 10 Nov 2023 13:34:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5165,7 +5198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d6ad861-4273-4759-b88b-c6a8308c5f5d
+      - aa4f4c6a-0eca-4036-8490-2aa1805d074a
     status: 200 OK
     code: 200
     duration: ""
@@ -5176,19 +5209,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:25 GMT
+      - Fri, 10 Nov 2023 13:34:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5198,7 +5231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ce74164-63e4-4687-a3ea-727689a4bcc0
+      - d8e8d64f-f416-49a0-8307-132158cf02b8
     status: 200 OK
     code: 200
     duration: ""
@@ -5209,19 +5242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:30 GMT
+      - Fri, 10 Nov 2023 13:34:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5231,7 +5264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6995330-8480-4028-9929-81dacafc8311
+      - 4fa31fd2-c4b3-4be9-94f7-cdd14c15dde4
     status: 200 OK
     code: 200
     duration: ""
@@ -5242,19 +5275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "650"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:35 GMT
+      - Fri, 10 Nov 2023 13:34:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5264,7 +5297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bd8c8bc-9727-4ea0-83fd-161e44d350a6
+      - 363828d9-5925-4cc7-9c47-241813b3b96c
     status: 200 OK
     code: 200
     duration: ""
@@ -5275,19 +5308,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:40 GMT
+      - Fri, 10 Nov 2023 13:34:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5297,7 +5330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74c268ed-132e-4771-ac89-72206a83f331
+      - 7cd69f68-39b4-4db0-bff4-47c781aea1fa
     status: 200 OK
     code: 200
     duration: ""
@@ -5308,19 +5341,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "650"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:45 GMT
+      - Fri, 10 Nov 2023 13:34:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5330,7 +5363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d504984-b849-43e5-96f7-400999f3f5d8
+      - e1876a09-3d1d-431d-8d08-ae635ad1f843
     status: 200 OK
     code: 200
     duration: ""
@@ -5341,19 +5374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "650"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:50 GMT
+      - Fri, 10 Nov 2023 13:34:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5363,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e2f5c02-dc33-4543-a3ef-d32d5e6cc780
+      - 0c43a3b9-70ab-4986-bfc8-619ae81a96b3
     status: 200 OK
     code: 200
     duration: ""
@@ -5374,19 +5407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:56 GMT
+      - Fri, 10 Nov 2023 13:34:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5396,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1207b469-3b3a-432f-ba1f-e99d954ac3eb
+      - 642471ab-22c9-4e85-89e9-3e15a59c36f4
     status: 200 OK
     code: 200
     duration: ""
@@ -5407,19 +5440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "650"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:01 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5429,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ee0f265-0880-481b-bc83-f2c08577f1c2
+      - 5281744d-cee3-4c94-baca-83926686ffc9
     status: 200 OK
     code: 200
     duration: ""
@@ -5440,241 +5473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "648"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3301baf6-bb6a-44ce-8279-ded05ec97f61
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f350e84-7585-4052-98b1-3e7dc0c7f9b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "648"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9552ebe1-b7bd-4a61-b823-8a9dd2e63eec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5abed34f-7cd8-43d1-b1c2-e7cbc00e1ef1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1233475-9112-4d11-9d3d-66e94dad30d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "648"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 474356ad-b9f0-4ae5-9216-2a43590594cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "709"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fef28077-d543-4fea-88cd-2494c58d1732
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -5683,7 +5485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a42342ae-e4dc-4419-bc71-bb0c9bcdb3d0
+      - 7f0f1b20-45eb-4e59-b500-0f1398297bba
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,19 +5506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d19c0541-1318-4930-9d44-981522e91477
+      - 34527f1c-7746-4bd4-9eda-3eecd34d4227
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,19 +5539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93214aed-0916-45ca-b6c1-2f9ebf27fb94
+      - da754193-b52c-4d18-b447-02ef4bf0ec9c
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,19 +5572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3685cf04-a78c-4dc5-8cb7-a76d4b53eec6
+      - 69033928-15ed-4bf7-9c6f-00d910d3bc25
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,19 +5605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:07 GMT
+      - Fri, 10 Nov 2023 13:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21f5e09d-0380-4665-83b6-92531d98ee80
+      - 841e3755-589d-481d-8205-394569fe0c43
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,19 +5638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:08 GMT
+      - Fri, 10 Nov 2023 13:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 003d8abc-2f32-45e6-ac0e-a97ce3bf5c5f
+      - d3826101-1768-4864-b5b6-d887271918da
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,19 +5671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "709"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:08 GMT
+      - Fri, 10 Nov 2023 13:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d75138c6-888a-461e-8420-215d0813fa0a
+      - c1d931a3-8a84-487d-82ee-1d6bbf6ea551
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,76 +5704,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2708"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e172b5c7-a14b-4428-a008-7f3c0cc6fe92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/available-types
-    method: GET
-  response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
-    headers:
-      Content-Length:
-      - "748"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 10497c73-70f1-4982-968f-e78df1adc9c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -5980,7 +5716,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:08 GMT
+      - Fri, 10 Nov 2023 13:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5990,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 178c0279-3a23-4ec2-a0e4-16f5b4c24193
+      - 8469541d-010e-440a-a4b0-97270e79b9bd
     status: 200 OK
     code: 200
     duration: ""
@@ -6001,19 +5737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "648"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:09 GMT
+      - Fri, 10 Nov 2023 13:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6023,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8891f79-d0a7-4e77-b156-af1094cd59ef
+      - f1c893b5-10f0-40dc-ac71-911321ceb4e0
     status: 200 OK
     code: 200
     duration: ""
@@ -6034,52 +5770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6dd695af-39b5-449a-b88b-b4444f67ce62
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "748"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:09 GMT
+      - Fri, 10 Nov 2023 13:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6089,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45f219b3-40cf-4699-a77d-1052c45e051c
+      - e192d892-bff5-4404-9e49-0d142f9a5175
     status: 200 OK
     code: 200
     duration: ""
@@ -6100,19 +5803,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:34:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89e11fdb-0a5b-4580-b76f-d3f350aabebc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "659"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:34:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 363a0b96-9a38-41a4-a8a1-a65ee0159689
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/available-types
+    method: GET
+  response:
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
+    headers:
+      Content-Length:
+      - "780"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:34:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0cc9aae-b771-4ec2-9d8e-b92dadc56ebd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320515900Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "654"
+      - "677"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:10 GMT
+      - Fri, 10 Nov 2023 13:34:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6122,7 +5924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55a9c5a2-9a91-40b0-bdc8-761b5d1e9392
+      - a6770729-ef29-4f7a-a223-3c3c70166cf6
     status: 200 OK
     code: 200
     duration: ""
@@ -6133,19 +5935,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320516Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:10 GMT
+      - Fri, 10 Nov 2023 13:34:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6155,7 +5957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b105b591-40f8-4b38-8ca0-5d5221e5570c
+      - c7df4b59-7549-448d-9944-257eddf1dd34
     status: 200 OK
     code: 200
     duration: ""
@@ -6166,19 +5968,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320516Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:15 GMT
+      - Fri, 10 Nov 2023 13:34:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6188,7 +5990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b2eb909-8a1a-4b08-99ec-35454bb999a4
+      - 1ad6bda2-01dd-41fb-8819-ff698416308b
     status: 200 OK
     code: 200
     duration: ""
@@ -6199,10 +6001,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"8209488d-594a-4812-8626-fac5f2638d54","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "674"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:34:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2f83cb0-060d-4052-b12d-4abfb17c7104
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "674"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:34:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ed83c8f-c42d-4681-9e9d-62893c9c4fe2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"3a32248e-d389-4d5b-979f-328f68abd855","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -6211,7 +6079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:20 GMT
+      - Fri, 10 Nov 2023 13:34:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6221,7 +6089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e5552ab-565c-42ab-833a-f817c10530d4
+      - 11d76918-c466-462d-8d28-1213d54e856e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6232,7 +6100,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
     method: DELETE
   response:
     body: ""
@@ -6240,7 +6108,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 07 Nov 2023 16:00:20 GMT
+      - Fri, 10 Nov 2023 13:34:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6250,7 +6118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85ea820e-e812-4bb2-885f-1126d22e8c5c
+      - e9cbf41b-f86a-4412-b4a5-c4f0d228137e
     status: 204 No Content
     code: 204
     duration: ""
@@ -6261,19 +6129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740129591Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854089967Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:20 GMT
+      - Fri, 10 Nov 2023 13:34:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6283,7 +6151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c5aeb40-23dc-4467-96d7-6f9b76b54d37
+      - 211bb420-66f9-4277-a42f-7d10188f768c
     status: 200 OK
     code: 200
     duration: ""
@@ -6294,19 +6162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740130Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854090Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:20 GMT
+      - Fri, 10 Nov 2023 13:34:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6316,12 +6184,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c141eae-3deb-404b-a0d1-816b981f322d
+      - 72227d6d-b87f-4a3a-953d-e37d2c9700a4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -6332,7 +6200,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -6341,9 +6209,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:21 GMT
+      - Fri, 10 Nov 2023 13:34:47 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6353,7 +6221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fd2098b-35d8-4bb5-9a81-53cfb5b1b818
+      - 6e474be8-9b8e-41cb-875b-98ca2978430f
     status: 201 Created
     code: 201
     duration: ""
@@ -6364,10 +6232,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
     method: GET
   response:
-    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -6376,7 +6244,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:21 GMT
+      - Fri, 10 Nov 2023 13:34:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6386,7 +6254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 839fad0c-2221-4e5d-877d-a6683a8be7d6
+      - 2c309106-f9a9-49cb-addb-9121634748ea
     status: 200 OK
     code: 200
     duration: ""
@@ -6397,19 +6265,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740130Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854090Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:26 GMT
+      - Fri, 10 Nov 2023 13:34:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6419,7 +6287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaeb2cd4-52ce-4b85-917e-fa808455d367
+      - 8c2089c7-4270-4784-a6ef-da2be7dfacbf
     status: 200 OK
     code: 200
     duration: ""
@@ -6430,10 +6298,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6442,7 +6310,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:34:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6452,7 +6320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cd67f98-43a2-4eb8-b51d-45765dbb7c73
+      - 6948fcea-a019-44cc-b7da-3261deaaadec
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6463,10 +6331,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -6475,7 +6343,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:34:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6485,12 +6353,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d00829cb-3d9a-4172-abb7-97ef0c9aebc5
+      - 7dd2c2be-7ca4-4501-ae3b-f34c0d018eee
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"multicloud","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
@@ -6501,16 +6369,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592693550Z","created_at":"2023-11-07T16:00:31.592693550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013467Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299916696Z","created_at":"2023-11-10T13:34:57.299916696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846206Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:34:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6520,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88d5a6ea-229c-4410-9b51-8b84aefe1a39
+      - 505e4f01-c22e-4f20-903f-e72178bd2ba6
     status: 200 OK
     code: 200
     duration: ""
@@ -6531,19 +6399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:34:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6553,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6ddff5f-4468-46c9-9110-020ad24f1315
+      - 60d5780e-f267-45a6-8a96-26a08cae2369
     status: 200 OK
     code: 200
     duration: ""
@@ -6564,19 +6432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:36 GMT
+      - Fri, 10 Nov 2023 13:35:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6586,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66e68d07-978c-4944-8cd2-afc97af0a4bf
+      - 4e17f9e4-14a0-4181-9191-e288c8447758
     status: 200 OK
     code: 200
     duration: ""
@@ -6597,19 +6465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:41 GMT
+      - Fri, 10 Nov 2023 13:35:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6619,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c7decd-74a2-4d46-bb99-a3fb83992ebc
+      - 1f99a729-cda9-4dbd-9109-ee0482eb9c30
     status: 200 OK
     code: 200
     duration: ""
@@ -6630,19 +6498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:46 GMT
+      - Fri, 10 Nov 2023 13:35:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6652,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6786e345-b45e-4c23-929e-b61160ce022a
+      - d5199352-fe06-42e5-8e8e-54163006d6c2
     status: 200 OK
     code: 200
     duration: ""
@@ -6663,19 +6531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:51 GMT
+      - Fri, 10 Nov 2023 13:35:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d78dfb5f-b5e5-4de7-b875-8430aff37739
+      - 0973b44e-1be9-436d-a4e1-69f2ef37c43d
     status: 200 OK
     code: 200
     duration: ""
@@ -6696,19 +6564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:56 GMT
+      - Fri, 10 Nov 2023 13:35:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6718,7 +6586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d42762f-d561-4f98-8b70-08055807b6f5
+      - 3d7672a5-cea5-44d6-8b16-057a9caba16f
     status: 200 OK
     code: 200
     duration: ""
@@ -6729,19 +6597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:02 GMT
+      - Fri, 10 Nov 2023 13:35:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6751,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c453854-9480-44c2-9433-cde939cbf8c7
+      - 8e0a00f7-73c0-46d3-b46b-80b8bcddc4e6
     status: 200 OK
     code: 200
     duration: ""
@@ -6762,19 +6630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:07 GMT
+      - Fri, 10 Nov 2023 13:35:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6784,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b205e04-feb6-4dae-9433-3bacc830d1d5
+      - e12df065-9496-4343-81d1-428550941153
     status: 200 OK
     code: 200
     duration: ""
@@ -6795,19 +6663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:12 GMT
+      - Fri, 10 Nov 2023 13:35:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6817,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7118b50-cb17-4cda-951a-dd13d5906c49
+      - 56f8216c-8409-4f16-8f1d-1b06a3aa3096
     status: 200 OK
     code: 200
     duration: ""
@@ -6828,19 +6696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:17 GMT
+      - Fri, 10 Nov 2023 13:35:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6850,7 +6718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7bfc0eb-bcc2-476e-989f-867ef10d9994
+      - db12a4c4-c399-4c6c-b918-fbbb1eadcbfc
     status: 200 OK
     code: 200
     duration: ""
@@ -6861,19 +6729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:22 GMT
+      - Fri, 10 Nov 2023 13:35:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6883,7 +6751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70fc90e5-9bf9-4b4a-b77b-99876873e4b1
+      - 18cafafe-6197-4e9c-a281-53ef08bfa7e7
     status: 200 OK
     code: 200
     duration: ""
@@ -6894,19 +6762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:27 GMT
+      - Fri, 10 Nov 2023 13:35:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6916,7 +6784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79365c94-db6c-4e66-9420-4bd4b2be6502
+      - b6323096-afc9-460f-a909-227c72ed9f62
     status: 200 OK
     code: 200
     duration: ""
@@ -6927,19 +6795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:32 GMT
+      - Fri, 10 Nov 2023 13:35:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6949,7 +6817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44d11b15-f928-4c83-9dd9-31fc533351ef
+      - c3eb6f0d-dc6b-4fda-b1ee-4948119ddcce
     status: 200 OK
     code: 200
     duration: ""
@@ -6960,19 +6828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:37 GMT
+      - Fri, 10 Nov 2023 13:36:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6982,7 +6850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3fd1957-be87-4756-a89d-815276cf76be
+      - 52224a5e-5214-467e-b7f1-fb9f0445231f
     status: 200 OK
     code: 200
     duration: ""
@@ -6993,19 +6861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:42 GMT
+      - Fri, 10 Nov 2023 13:36:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7015,7 +6883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b14c96a-ea6c-4635-ae4a-12e6cfbe2685
+      - 61c68e62-e1b6-42d9-9b7f-20ff64f04b3d
     status: 200 OK
     code: 200
     duration: ""
@@ -7026,19 +6894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:47 GMT
+      - Fri, 10 Nov 2023 13:36:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7048,7 +6916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0907aa6-955c-4116-ba82-63ce396e50d2
+      - 61353c33-df3e-44ad-b2cc-7153769f0452
     status: 200 OK
     code: 200
     duration: ""
@@ -7059,19 +6927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRYcFJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5lbEV4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTVQQ20xelZ6WkpTelZCZFdKVk1UWmlTbFJsUm5aeWNETlpjekZQSzI5UVNuQlJWR0pNYWtnNUsxcHpZMFJqYVVwaGVqY3JTV1pGTXpoUlNuRkRVR0kzVW1RS0wxazVaazFOT0RsdFFVeFlORTR3VVhsNFN6SnpaVVZtY1doSlVETkpOWFJEVUU5bllVNTFaMjExUmpadVkzcFVSSE5OY1dkc1R5OHJWRk4yZEdsNGR3cHBhaTlEZVhVd01IZzFObmxRV0dweGRtSjBaVmxvU2t4VldYSllSVWxtZEZCU01qWXpTemd3TVU1RlZuWnFhV0Y2ZFZOclN6QjNjM2hQWld0b2RYVnhDbFowT1ROUFkwaExha1pzTUdsWllYWnZOREE0YzFJek1XNUtTa1YyU1RSUWRWWndRMFI0UW5CclVIQjJSbnAwTlRkUk5YcHlUR050V1U1MVV6VlFTWElLZGtGNmVHODVVaXRYWmpoTGFHeDRWRWc1YUdGbkswNXdXWEl3VURaVk0wOVBaRXMxVkV4MFZWTlpSRmRtV2psSlRIbHhiRzVtVTJOS1ZHVkhNalZ6YkFwS2Qxb3djVUZDYUdkT2NGQkphSEpzUkVJNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2VWbzVPVFZaUmxKYVRHcEplbXBrUWk4MVJqTTNlWGRsYUhSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JsQjVUMFpZZWtKaFdHTjNkWG9yYWxKUWVtY3lORTFYY1UxVU5VaDZiRVYxUjJSaFkwcHdjV1ZTVG5ScWRqUmpUQXA0YWtkckswUndNSGRRVm04Mk9UTktNelE1Wmxab2MwczVXRnBJVVZadmFHeG1ia2s1V1ROVGR6QktWMGRLVjJGeWJrTjVWbFpOTW14Uk5uaFRPWEpvQ2t0UlZHcG5VVTB4VmpoT2QyMXlUR2xrT1dWck5uazRSV3REZUVVNFpraHVia2RGZVRGcmRqZDNVbTFSVkRnNE5ETlJNbWxMYVZnd1prVnJSV3NyY1UwS2VUaE1XbkJSVEVGVWFGVlBaRkU0VjJKTWEwdG9ORGhNV25kcVpISmhMMHgwUlV0UVJ6TnJVME4xTWxRclZFbDNNblk1WVZaS05qRm9VVWxJZFhkbWNncGxUbGN4VW01blZsVTBPVXRXUm5SM1J6QktabUZhUW5sWmFUY3JTMjFtTTJSNFlteGpVelJtU1U5dlVUbFZUakpSVFRCT1YxcG1XRXhRUm5SRFpHZGFDbkYxYjI5RlNYTndNVkZ3Ym1kRlMyeDNiWHBoYzBzNFRtc3hkV1J4ZUZOeWVFWkJTUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTNhYWM4ZmItZDY1Ni00ODY0LWI1MGItNmU5YzIxMDhlMTBkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcFBnS1lnblRoZTgyeGEyQjRqR0pTSzNBYVdza2JkUE1aV212bUd4WVcxNGM5VWd1RVRkQjh4Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1440"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:52 GMT
+      - Fri, 10 Nov 2023 13:36:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7081,7 +6949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d26da0c-0fbc-45dc-98ab-aa0a6b79abaf
+      - f3d41d14-e089-4a62-b43e-cc50104b8b51
     status: 200 OK
     code: 200
     duration: ""
@@ -7092,19 +6960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:01:57 GMT
+      - Fri, 10 Nov 2023 13:36:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7114,144 +6982,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 637ecd9e-b953-4c5d-9478-74ce5880d185
+      - ac01ffcb-4a39-4a1f-a323-49de430183cc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1437"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:02:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d73688b9-8e34-4be6-bb25-ccd771d98ad4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1437"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:02:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e6f5f7f8-0d41-4f51-9028-15c8deecfd0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUkJlazFzYjFoRVZFMTZUVlJGZDA1cVJUSk5SRUY2VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFE0Q21JcmRFWnVRbW96UmxSUGNYRkxVSGhLVFVwNFNVMTZlSEF5YkM5a1JsWlZZVVY2VkVRNVFsTXpiMlF6UkZOVmFGVkNXVTlQTjFoVVUycEJVVEZSUzJRS2EwMUpiV0ZuTlVKWlMzWlVlbTVGZFVOR1dESlJlRWNyVFVFMVVHaHBjRWN3Y0dRNWRXdE1UMHhTVFRJM1dFUlZhVkpLWW05a1RVbG5OSEJuTmxRMlJ3cEdORlZrVTJSa2FqWm5VWEpCVFhKR2FrOUxibEY2V0U1TVMyMXRlRWxpUTA4elFXWkRWekZqYUZOellYZHlTMmRqWW5oeVltVlFVa3cxSzBoVllYQnhDbUUwTkRrNVZFVXpjMjVoZURkVkwwRnBjM1JSUXpBcmRFUTBjemxvVEdoUFltZ3hSRnAxT0hCU1YycEdWMnhQVDJZclNsQmpXa1kzSzFOQ1ozTnRWSGNLYVRZMWVreDVjVlJMU1VoSUwyMUNPWEpPVFdkblRpdEhaMUpRY0RGVUwzaDNNalV2Tkc5bFJXbFBja2MwTmpkMlZFTjRTR2g1WXpkUU1WWlZkamR6YWdwUFZUUXhPVVJxWTJOS1pqUnhka2RFYkV4elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZqSmxOWE5DVUcxTVlUSnlUR2Q1TURCRGEzUlFXSEZEVDJOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpVVkZORXhZTjNGak5UWlBhRUUzYWl0eU1scGhRVFpTYWtaNFJsbHhiRlZOYVVrM1RDdG5kVTlqVjFsTVRqTm9NQW95YlZCT2QySkJXVkZRWkdoSGIyRmFRbWhMYms1YVNqUmxSVVp6YlZoS1ZYZG5WeTg0ZW5VMlVHUndNMGwwU1ZreWVWSTRWMmRVTDJaU09WcEtkMVJIQ25oV04waGFjV3A0VTJweFIyNDVkbTlaVnpCblduTm5hMlo0T0ZBd1kydDJOV2MyWmtOeFYxWnNabk5MVlhCNWRFcE9MME5KTlhWbFNUbGFTMUpwVTJjS2RIRkhSM0kyUTJKaFlWVnNaQzluWmtKRlFVUk9iV0pIUVRVelRFWTJjMWczYWtzdk9WSlZaSGMzVUdsV1NGQlBjMU40VFZsRVVWSjNTRTF1T0daQlRBcFlUR3RJWTFSSVNEWmpTazlSWkdkdFdYWXhaSFZCVmpOcFVYTk5TM2RFZUZGQlNXUktiRmhDTWxoQlVUbE5lRlpLZG1GaVNEWnhMMkZKYVdob1FUaGtDbUpVZWxGWVVtdE1TVUo2TUhoUloyNTJNakExYldsS1JtSlBTWEV2WlZsUk5XdFhWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGUxYTNjYjItMjgzMy00N2UyLWJhZWYtMzA5Y2JhZWE3ZTVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPZHhUUjlZdzJ1dk44Z3ZPTWxhM2w1QWN2Tmt1T0xLcUJORVc0cXdJa3paMVRDeFdHMjMzZldEYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2708"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:02:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62098921-bae1-4b42-996c-cc50160e86d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1437"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:02:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ed9eefb-3033-4b3f-876d-2395980d6fae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -7259,19 +6995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177947680Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243304Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "653"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:03 GMT
+      - Fri, 10 Nov 2023 13:36:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7281,7 +7017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22155d5c-cfbf-44bd-ab5e-413058130a06
+      - 04329fb1-a4b6-48a2-b85a-e5e801e8a49a
     status: 200 OK
     code: 200
     duration: ""
@@ -7292,19 +7028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:03 GMT
+      - Fri, 10 Nov 2023 13:36:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7314,7 +7050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a998acdb-3c21-4e26-a747-27ff020d9344
+      - e3dfb088-8934-4fd9-b859-a6e2143d7859
     status: 200 OK
     code: 200
     duration: ""
@@ -7325,19 +7061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:08 GMT
+      - Fri, 10 Nov 2023 13:36:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7347,7 +7083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bee0cdb-ba67-42a9-89d5-7cda9377f4ca
+      - ef9a7322-2579-4fcd-9716-54d1829624ec
     status: 200 OK
     code: 200
     duration: ""
@@ -7358,19 +7094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:13 GMT
+      - Fri, 10 Nov 2023 13:36:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +7116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7918fc6d-ae9d-4de3-bc06-e0b539913293
+      - e10945e8-743b-4196-bb08-13090febe3ea
     status: 200 OK
     code: 200
     duration: ""
@@ -7391,19 +7127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:18 GMT
+      - Fri, 10 Nov 2023 13:36:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +7149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55531f5-83e7-4bf5-83d1-42a5fb7474af
+      - 97694042-20b8-4887-bf91-9022edb94f98
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,19 +7160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:23 GMT
+      - Fri, 10 Nov 2023 13:36:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +7182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7beef514-e232-489d-adf9-8be42e1f6189
+      - 06df751d-2c18-4efd-ac03-b1a40b20efa4
     status: 200 OK
     code: 200
     duration: ""
@@ -7457,19 +7193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:28 GMT
+      - Fri, 10 Nov 2023 13:36:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7479,7 +7215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb823c30-66b1-4552-b596-0ee8269eac02
+      - d74715b6-6acf-4027-bc20-c0a7859c0def
     status: 200 OK
     code: 200
     duration: ""
@@ -7490,19 +7226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:33 GMT
+      - Fri, 10 Nov 2023 13:36:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +7248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd04dc4-d003-45ee-994a-ceb587bfc7d9
+      - a2834f35-91d0-47d9-996e-b25c07f41d23
     status: 200 OK
     code: 200
     duration: ""
@@ -7523,19 +7259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:38 GMT
+      - Fri, 10 Nov 2023 13:36:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7545,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7ffdc29-b6f8-49ca-904b-97caf0b7b579
+      - 405a4d0a-3b47-405c-bde9-1923e34b6c26
     status: 200 OK
     code: 200
     duration: ""
@@ -7556,19 +7292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:44 GMT
+      - Fri, 10 Nov 2023 13:36:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7578,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa4299c-8a4d-4993-93fa-1ca63d032023
+      - fd713a79-9841-49b8-add6-5caf329c7313
     status: 200 OK
     code: 200
     duration: ""
@@ -7589,19 +7325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:49 GMT
+      - Fri, 10 Nov 2023 13:36:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7611,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59a401aa-9420-40d7-aa49-398c3f2ce9b6
+      - 3a1d9b36-363a-4ca7-84c4-5b1f0d775359
     status: 200 OK
     code: 200
     duration: ""
@@ -7622,19 +7358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:54 GMT
+      - Fri, 10 Nov 2023 13:36:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7644,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1e697e3-ea93-413a-a1e5-0f0ec41cb3a9
+      - 64f63154-618f-4135-b9c3-1b991d381765
     status: 200 OK
     code: 200
     duration: ""
@@ -7655,19 +7391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:02:59 GMT
+      - Fri, 10 Nov 2023 13:37:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7677,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7d5c5a6-f514-4d07-856a-498b756b0718
+      - 6c757096-082d-4ce0-bbd3-646b10e64451
     status: 200 OK
     code: 200
     duration: ""
@@ -7688,19 +7424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:04 GMT
+      - Fri, 10 Nov 2023 13:37:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7710,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 856f0aa6-75b7-492d-a690-feda49a17e5b
+      - 0cc46e8d-d177-4434-92bb-db4aed577cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -7721,19 +7457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:09 GMT
+      - Fri, 10 Nov 2023 13:37:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7743,7 +7479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c473e5b5-4fd7-4f5b-baec-b419d31c9f5a
+      - e8124704-1c90-42da-9981-804aebce75e4
     status: 200 OK
     code: 200
     duration: ""
@@ -7754,19 +7490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:14 GMT
+      - Fri, 10 Nov 2023 13:37:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7776,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 897f5d09-a764-42bb-aa4d-2f259299bf10
+      - 5052f5e6-7eca-4170-80fd-63e8830dba29
     status: 200 OK
     code: 200
     duration: ""
@@ -7787,19 +7523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:19 GMT
+      - Fri, 10 Nov 2023 13:37:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7809,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8b1568-4436-4d06-a4d6-eb0d76e2d791
+      - 9044abd4-b035-4b3d-967c-c3678dc6053b
     status: 200 OK
     code: 200
     duration: ""
@@ -7820,19 +7556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:24 GMT
+      - Fri, 10 Nov 2023 13:37:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7842,7 +7578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35299821-bd08-4aac-8ad4-f4fb5b309e80
+      - 63e0e3ab-d215-4064-8686-8bfa8a68e4ac
     status: 200 OK
     code: 200
     duration: ""
@@ -7853,19 +7589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:29 GMT
+      - Fri, 10 Nov 2023 13:37:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7875,7 +7611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f18beee-fe68-4969-b727-65e2e15bdf40
+      - da621b7b-cd15-4bdc-b5c6-271841b4d18b
     status: 200 OK
     code: 200
     duration: ""
@@ -7886,19 +7622,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:34 GMT
+      - Fri, 10 Nov 2023 13:37:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7908,7 +7644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf516dbb-e0e3-4f04-8ff9-4959479931c1
+      - 599ab9d6-2bc7-4e61-b2e3-b410cbc15df0
     status: 200 OK
     code: 200
     duration: ""
@@ -7919,19 +7655,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:39 GMT
+      - Fri, 10 Nov 2023 13:37:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7941,7 +7677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d81671d5-7b83-4ffb-9c0d-c0b04c6a2997
+      - 741ac7a5-8bec-4cf0-9473-d416150a6806
     status: 200 OK
     code: 200
     duration: ""
@@ -7952,19 +7688,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:44 GMT
+      - Fri, 10 Nov 2023 13:37:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7974,7 +7710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6db61a78-b83e-4648-b884-bba3cc46e4e1
+      - 7dac89df-923b-46c7-8e5f-fe5661ad6fd7
     status: 200 OK
     code: 200
     duration: ""
@@ -7985,19 +7721,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:49 GMT
+      - Fri, 10 Nov 2023 13:37:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8007,7 +7743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3a37417-4ecd-4367-b966-92606926b634
+      - 7bd9f4bd-a513-45d1-a5b1-aa28847de754
     status: 200 OK
     code: 200
     duration: ""
@@ -8018,19 +7754,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "650"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:54 GMT
+      - Fri, 10 Nov 2023 13:38:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8040,7 +7776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de8e6198-a977-4f77-bb94-3429bfa00c40
+      - 8a5f4647-5de8-49e4-a09c-d2346ebca853
     status: 200 OK
     code: 200
     duration: ""
@@ -8051,19 +7787,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:59 GMT
+      - Fri, 10 Nov 2023 13:38:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8073,7 +7809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bbc6f84-014e-43b6-a98a-d07bcf25e527
+      - 8fdef80a-6052-420f-9343-0b010df71dd2
     status: 200 OK
     code: 200
     duration: ""
@@ -8084,19 +7820,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:03:59 GMT
+      - Fri, 10 Nov 2023 13:38:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8106,7 +7842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73dce3eb-9fc7-4d91-b993-cab58fb7e614
+      - 541d6d3b-6841-4467-aa43-43a490bbc027
     status: 200 OK
     code: 200
     duration: ""
@@ -8117,19 +7853,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/nodes?order_by=created_at_asc&page=1&pool_id=021b5870-cc24-4f88-92b4-060c684209db&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:02:03.724300Z","error_message":null,"id":"852e2de7-8494-48ab-87b0-0757a436b6a6","name":"scw-test-pool-placeme-test-pool-placeme-852e2d","pool_id":"021b5870-cc24-4f88-92b4-060c684209db","provider_id":"scaleway://instance/nl-ams-1/cf102a29-dcf2-4ebb-85d4-6beafb1ee12e","public_ip_v4":"51.15.66.165","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:03:56.068709Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:38:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8139,7 +7875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a396f814-0ba6-4f81-813a-f88e99aea060
+      - 49d7dcf6-8640-4224-9e45-d1c3d9a0bb21
     status: 200 OK
     code: 200
     duration: ""
@@ -8150,19 +7886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1437"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:38:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8172,7 +7908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad86d33d-43b1-4407-a8cb-6e16b099a64e
+      - eeef5e5b-8466-43fb-92e0-1e84904fc0e9
     status: 200 OK
     code: 200
     duration: ""
@@ -8183,19 +7919,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:38:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8205,7 +7941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b03b5c3f-1aab-4bfc-ad31-cda86d51b8c8
+      - 682815b9-925c-4953-9ca4-67218563c193
     status: 200 OK
     code: 200
     duration: ""
@@ -8216,19 +7952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1437"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:38:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8238,7 +7974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6de9b5da-1e8d-473b-8fb1-3d73895b05c1
+      - 02e1ba32-a8ca-46f3-bebd-96cbb10b668d
     status: 200 OK
     code: 200
     duration: ""
@@ -8249,10 +7985,373 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:38:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24e65575-b614-42c2-a415-fe992fd3bc55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:38:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11777550-d8ad-46b9-8056-375297e327cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:38:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b14f834c-4008-4bd2-b607-5b00950763a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:38:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea231b09-ce11-4e20-9e91-ccca41758a97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:38:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 793b25fb-174d-471f-85f1-40152d2d65b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4380cc59-0497-4aad-b1a4-9916af66dc0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bc094642-0fc7-408c-af25-4b61a5bb1c13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/nodes?order_by=created_at_asc&page=1&pool_id=0dcdff54-d609-4715-9d67-ec96bc263841&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:36:09.259332Z","error_message":null,"id":"805f244b-2f21-429d-bd92-de1a17a75f48","name":"scw-test-pool-placeme-test-pool-placeme-805f24","pool_id":"0dcdff54-d609-4715-9d67-ec96bc263841","provider_id":"scaleway://instance/nl-ams-1/062e03c2-60a7-4b65-9eca-c189b2964d8f","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:39:00.456279Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7cfe261-848f-43ec-9d9c-d1e07b42bf01
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc6c843e-58f0-429e-942d-761ae925a8c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d95aa416-1f13-4520-8493-d9d700d08b66
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce212e4e-6abd-4f48-8949-8886c0e94ce9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -8261,7 +8360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:39:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8271,7 +8370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4380fa8f-9784-4886-96ae-336084b3e7c7
+      - a8c2bbc4-c1de-46b2-98ac-6867f72d419d
     status: 200 OK
     code: 200
     duration: ""
@@ -8282,19 +8381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUkJlazFzYjFoRVZFMTZUVlJGZDA1cVJUSk5SRUY2VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFE0Q21JcmRFWnVRbW96UmxSUGNYRkxVSGhLVFVwNFNVMTZlSEF5YkM5a1JsWlZZVVY2VkVRNVFsTXpiMlF6UkZOVmFGVkNXVTlQTjFoVVUycEJVVEZSUzJRS2EwMUpiV0ZuTlVKWlMzWlVlbTVGZFVOR1dESlJlRWNyVFVFMVVHaHBjRWN3Y0dRNWRXdE1UMHhTVFRJM1dFUlZhVkpLWW05a1RVbG5OSEJuTmxRMlJ3cEdORlZrVTJSa2FqWm5VWEpCVFhKR2FrOUxibEY2V0U1TVMyMXRlRWxpUTA4elFXWkRWekZqYUZOellYZHlTMmRqWW5oeVltVlFVa3cxSzBoVllYQnhDbUUwTkRrNVZFVXpjMjVoZURkVkwwRnBjM1JSUXpBcmRFUTBjemxvVEdoUFltZ3hSRnAxT0hCU1YycEdWMnhQVDJZclNsQmpXa1kzSzFOQ1ozTnRWSGNLYVRZMWVreDVjVlJMU1VoSUwyMUNPWEpPVFdkblRpdEhaMUpRY0RGVUwzaDNNalV2Tkc5bFJXbFBja2MwTmpkMlZFTjRTR2g1WXpkUU1WWlZkamR6YWdwUFZUUXhPVVJxWTJOS1pqUnhka2RFYkV4elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZqSmxOWE5DVUcxTVlUSnlUR2Q1TURCRGEzUlFXSEZEVDJOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpVVkZORXhZTjNGak5UWlBhRUUzYWl0eU1scGhRVFpTYWtaNFJsbHhiRlZOYVVrM1RDdG5kVTlqVjFsTVRqTm9NQW95YlZCT2QySkJXVkZRWkdoSGIyRmFRbWhMYms1YVNqUmxSVVp6YlZoS1ZYZG5WeTg0ZW5VMlVHUndNMGwwU1ZreWVWSTRWMmRVTDJaU09WcEtkMVJIQ25oV04waGFjV3A0VTJweFIyNDVkbTlaVnpCblduTm5hMlo0T0ZBd1kydDJOV2MyWmtOeFYxWnNabk5MVlhCNWRFcE9MME5KTlhWbFNUbGFTMUpwVTJjS2RIRkhSM0kyUTJKaFlWVnNaQzluWmtKRlFVUk9iV0pIUVRVelRFWTJjMWczYWtzdk9WSlZaSGMzVUdsV1NGQlBjMU40VFZsRVVWSjNTRTF1T0daQlRBcFlUR3RJWTFSSVNEWmpTazlSWkdkdFdYWXhaSFZCVmpOcFVYTk5TM2RFZUZGQlNXUktiRmhDTWxoQlVUbE5lRlpLZG1GaVNEWnhMMkZKYVdob1FUaGtDbUpVZWxGWVVtdE1TVUo2TUhoUloyNTJNakExYldsS1JtSlBTWEV2WlZsUk5XdFhWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGUxYTNjYjItMjgzMy00N2UyLWJhZWYtMzA5Y2JhZWE3ZTVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPZHhUUjlZdzJ1dk44Z3ZPTWxhM2w1QWN2Tmt1T0xLcUJORVc0cXdJa3paMVRDeFdHMjMzZldEYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRYcFJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5lbEV4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTVQQ20xelZ6WkpTelZCZFdKVk1UWmlTbFJsUm5aeWNETlpjekZQSzI5UVNuQlJWR0pNYWtnNUsxcHpZMFJqYVVwaGVqY3JTV1pGTXpoUlNuRkRVR0kzVW1RS0wxazVaazFOT0RsdFFVeFlORTR3VVhsNFN6SnpaVVZtY1doSlVETkpOWFJEVUU5bllVNTFaMjExUmpadVkzcFVSSE5OY1dkc1R5OHJWRk4yZEdsNGR3cHBhaTlEZVhVd01IZzFObmxRV0dweGRtSjBaVmxvU2t4VldYSllSVWxtZEZCU01qWXpTemd3TVU1RlZuWnFhV0Y2ZFZOclN6QjNjM2hQWld0b2RYVnhDbFowT1ROUFkwaExha1pzTUdsWllYWnZOREE0YzFJek1XNUtTa1YyU1RSUWRWWndRMFI0UW5CclVIQjJSbnAwTlRkUk5YcHlUR050V1U1MVV6VlFTWElLZGtGNmVHODVVaXRYWmpoTGFHeDRWRWc1YUdGbkswNXdXWEl3VURaVk0wOVBaRXMxVkV4MFZWTlpSRmRtV2psSlRIbHhiRzVtVTJOS1ZHVkhNalZ6YkFwS2Qxb3djVUZDYUdkT2NGQkphSEpzUkVJNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2VWbzVPVFZaUmxKYVRHcEplbXBrUWk4MVJqTTNlWGRsYUhSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JsQjVUMFpZZWtKaFdHTjNkWG9yYWxKUWVtY3lORTFYY1UxVU5VaDZiRVYxUjJSaFkwcHdjV1ZTVG5ScWRqUmpUQXA0YWtkckswUndNSGRRVm04Mk9UTktNelE1Wmxab2MwczVXRnBJVVZadmFHeG1ia2s1V1ROVGR6QktWMGRLVjJGeWJrTjVWbFpOTW14Uk5uaFRPWEpvQ2t0UlZHcG5VVTB4VmpoT2QyMXlUR2xrT1dWck5uazRSV3REZUVVNFpraHVia2RGZVRGcmRqZDNVbTFSVkRnNE5ETlJNbWxMYVZnd1prVnJSV3NyY1UwS2VUaE1XbkJSVEVGVWFGVlBaRkU0VjJKTWEwdG9ORGhNV25kcVpISmhMMHgwUlV0UVJ6TnJVME4xTWxRclZFbDNNblk1WVZaS05qRm9VVWxJZFhkbWNncGxUbGN4VW01blZsVTBPVXRXUm5SM1J6QktabUZhUW5sWmFUY3JTMjFtTTJSNFlteGpVelJtU1U5dlVUbFZUakpSVFRCT1YxcG1XRXhRUm5SRFpHZGFDbkYxYjI5RlNYTndNVkZ3Ym1kRlMyeDNiWHBoYzBzNFRtc3hkV1J4ZUZOeWVFWkJTUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTNhYWM4ZmItZDY1Ni00ODY0LWI1MGItNmU5YzIxMDhlMTBkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcFBnS1lnblRoZTgyeGEyQjRqR0pTSzNBYVdza2JkUE1aV212bUd4WVcxNGM5VWd1RVRkQjh4Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:39:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8304,7 +8403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8435bfae-43c0-4066-8782-3dfa8fb93afe
+      - 9041f7e6-1fd7-4476-abae-2c96dc0944a0
     status: 200 OK
     code: 200
     duration: ""
@@ -8315,19 +8414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "648"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:39:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8337,7 +8436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40601852-be2b-4471-b7e9-8637dd96970b
+      - 4c179702-4ac0-4bd8-9d58-2965b6e0821f
     status: 200 OK
     code: 200
     duration: ""
@@ -8348,19 +8447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/nodes?order_by=created_at_asc&page=1&pool_id=021b5870-cc24-4f88-92b4-060c684209db&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/nodes?order_by=created_at_asc&page=1&pool_id=0dcdff54-d609-4715-9d67-ec96bc263841&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:02:03.724300Z","error_message":null,"id":"852e2de7-8494-48ab-87b0-0757a436b6a6","name":"scw-test-pool-placeme-test-pool-placeme-852e2d","pool_id":"021b5870-cc24-4f88-92b4-060c684209db","provider_id":"scaleway://instance/nl-ams-1/cf102a29-dcf2-4ebb-85d4-6beafb1ee12e","public_ip_v4":"51.15.66.165","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:03:56.068709Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:36:09.259332Z","error_message":null,"id":"805f244b-2f21-429d-bd92-de1a17a75f48","name":"scw-test-pool-placeme-test-pool-placeme-805f24","pool_id":"0dcdff54-d609-4715-9d67-ec96bc263841","provider_id":"scaleway://instance/nl-ams-1/062e03c2-60a7-4b65-9eca-c189b2964d8f","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:39:00.456279Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "604"
+      - "620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:00 GMT
+      - Fri, 10 Nov 2023 13:39:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8370,7 +8469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 597d87ca-ff1b-4b53-9ad8-af0c630cbc9b
+      - b164311c-275b-4296-9292-1a89c76ab265
     status: 200 OK
     code: 200
     duration: ""
@@ -8381,19 +8480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748425Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838546593Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "654"
+      - "677"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:01 GMT
+      - Fri, 10 Nov 2023 13:39:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8403,7 +8502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0a6dfcd-9db2-448b-bd6d-90e7ba97d26e
+      - 477875cf-1380-4e18-b840-e8ebc4ee936c
     status: 200 OK
     code: 200
     duration: ""
@@ -8414,19 +8513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:02 GMT
+      - Fri, 10 Nov 2023 13:39:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8436,7 +8535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa1213e-b76a-4466-8a22-7c4ac637a74b
+      - 22f63d8e-6a1c-49de-87ad-57a1c4cbbe82
     status: 200 OK
     code: 200
     duration: ""
@@ -8447,19 +8546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:07 GMT
+      - Fri, 10 Nov 2023 13:39:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8469,7 +8568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7c60140-1ebb-4345-8794-2168f4ab939a
+      - 98dcc426-3bc5-474e-a1b8-50f19594432d
     status: 200 OK
     code: 200
     duration: ""
@@ -8480,19 +8579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:12 GMT
+      - Fri, 10 Nov 2023 13:39:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8502,7 +8601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68dfcff1-37a2-4ee0-ab12-3be6d8052caf
+      - 15143f18-6c7e-4878-b699-71cb3ff24597
     status: 200 OK
     code: 200
     duration: ""
@@ -8513,19 +8612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "651"
+      - "674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:17 GMT
+      - Fri, 10 Nov 2023 13:39:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8535,7 +8634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9fc0a91-bc6b-421e-a2dc-9982b0a47148
+      - b1330a03-caec-4dc1-a6c0-e13b13f90dc3
     status: 200 OK
     code: 200
     duration: ""
@@ -8546,109 +8645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "651"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:04:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 761efef3-4e93-4864-99ce-5e214c5bef4c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "651"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:04:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dad4a835-392b-499c-bafc-005a9d3b0137
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "651"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:04:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d254699d-2434-4dfa-961c-5e4a64f64b2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"021b5870-cc24-4f88-92b4-060c684209db","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"0dcdff54-d609-4715-9d67-ec96bc263841","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -8657,7 +8657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:37 GMT
+      - Fri, 10 Nov 2023 13:39:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8667,7 +8667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34efbb8c-046f-467e-b8e8-0a926feca6d4
+      - 3349aec5-5c79-419b-8c6d-05a055a2bef9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8678,19 +8678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417156Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269282Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1443"
+      - "1488"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:37 GMT
+      - Fri, 10 Nov 2023 13:39:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8700,7 +8700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7268da73-872a-4f63-8915-6e2601cedfdd
+      - c5c54e23-b6a1-4582-b0ae-9ca5f90aa491
     status: 200 OK
     code: 200
     duration: ""
@@ -8711,40 +8711,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1440"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:04:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01230575-bab2-4014-a521-a7cb3d4c9da8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
     method: DELETE
   response:
     body: ""
@@ -8752,7 +8719,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 07 Nov 2023 16:04:37 GMT
+      - Fri, 10 Nov 2023 13:39:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8762,7 +8729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0472167b-f80a-4aa6-85df-68ff327026fa
+      - 48e5aa5f-241c-4631-8609-b2e8b749d221
     status: 204 No Content
     code: 204
     duration: ""
@@ -8773,19 +8740,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:42 GMT
+      - Fri, 10 Nov 2023 13:39:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8795,7 +8762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b74d5e42-5a04-48e5-86f0-593dc09e65a4
+      - 2bf42dd7-0fbe-41c4-9690-c59b7b9a4ff9
     status: 200 OK
     code: 200
     duration: ""
@@ -8806,19 +8773,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "128"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:47 GMT
+      - Fri, 10 Nov 2023 13:39:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8828,7 +8795,205 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e051d3a8-e664-4cc1-8346-6e7c9da1be57
+      - 19be9516-9f0c-448e-93ef-850789569be4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a360e14-f80a-4bf8-90c7-8f07d420eebf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9be2a5c5-79c7-4fb5-8db7-16eb7859e59b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49915e88-61e0-46b7-8830-00b533c0276c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a04f74b1-ff97-4dcf-85fa-c3061437c9d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68f75d85-b5bb-4ee1-85e3-1cab803bd965
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 304d31e6-27de-4fa5-a864-678542eb24ec
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8839,10 +9004,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8851,7 +9016,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:04:47 GMT
+      - Fri, 10 Nov 2023 13:39:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8861,7 +9026,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3ce1cff-ee09-4697-a1a2-2573991343e3
+      - cfe19342-7d85-474e-8247-fcb2efd1a963
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"0dcdff54-d609-4715-9d67-ec96bc263841","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:39:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90a71784-1190-48c3-ac99-f82f8ca6404e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfdd2b05-52d8-4a76-9fb8-2323342fcb52
+      - b31d75eb-18dc-4c7d-bc78-3d2128ede127
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-private-network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
+    body: '{"name":"test-k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
+    body: '{"created_at":"2023-11-10T13:17:42.343618Z","id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-11-10T13:17:42.343618Z"}'
     headers:
       Content-Length:
-      - "347"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:51 GMT
+      - Fri, 10 Nov 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31fc8e88-3e3e-46dc-8ae2-698092f4a882
+      - 768d417c-910c-4d3a-85ea-a8e1d7e5716a
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
+    body: '{"created_at":"2023-11-10T13:17:42.343618Z","id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-11-10T13:17:42.343618Z"}'
     headers:
       Content-Length:
-      - "347"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:51 GMT
+      - Fri, 10 Nov 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab8834f7-b5bd-463a-8d2e-24ee987eb31c
+      - bd7f5415-ed26-43a3-beae-651199471b08
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-private-network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
+    body: '{"name":"test-k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
+    body: '{"created_at":"2023-11-10T13:17:42.602847Z","dhcp_enabled":true,"id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:42.602847Z","id":"3270d81e-9182-44bf-9a3d-f1406419d094","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:17:42.602847Z"},{"created_at":"2023-11-10T13:17:42.602847Z","id":"296f03bb-e3ae-4461-8593-beb5fd2f5374","subnet":"fd63:256c:45f7:e86::/64","updated_at":"2023-11-10T13:17:42.602847Z"}],"tags":[],"updated_at":"2023-11-10T13:17:42.602847Z","vpc_id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c"}'
     headers:
       Content-Length:
-      - "708"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:17:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ab82976-4173-4223-b489-288449ca8559
+      - f314cde4-0676-4548-a8e9-2ce5ed51b768
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3ad9e923-b5ae-4680-b796-7d4a3cd12b96
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
+    body: '{"created_at":"2023-11-10T13:17:42.602847Z","dhcp_enabled":true,"id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:42.602847Z","id":"3270d81e-9182-44bf-9a3d-f1406419d094","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:17:42.602847Z"},{"created_at":"2023-11-10T13:17:42.602847Z","id":"296f03bb-e3ae-4461-8593-beb5fd2f5374","subnet":"fd63:256c:45f7:e86::/64","updated_at":"2023-11-10T13:17:42.602847Z"}],"tags":[],"updated_at":"2023-11-10T13:17:42.602847Z","vpc_id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c"}'
     headers:
       Content-Length:
-      - "708"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:17:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,12 +170,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896854b8-11ce-4348-a33f-8f64c0878d30
+      - 95226506-9936-482c-b9fc-f95c55916cdc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-k8s-private-network","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-private-network","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96"}'
     form: {}
     headers:
       Content-Type:
@@ -186,16 +186,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540355Z","created_at":"2023-11-07T15:49:53.385540355Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.410350167Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604339Z","created_at":"2023-11-10T13:17:44.019604339Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.107244764Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1524"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -205,7 +205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8e7b9c6-4a1a-45b7-8f05-42b4c701d17c
+      - 0924c819-c720-43cc-aa93-cf4b1cbf4062
     status: 200 OK
     code: 200
     duration: ""
@@ -216,19 +216,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.410350Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.107245Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -238,7 +238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eeab453-8e63-4620-91e7-41b6ac5a8856
+      - 80ba5c6d-4ce3-4aa0-9637-a811809f07c7
     status: 200 OK
     code: 200
     duration: ""
@@ -249,19 +249,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:45.932800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1475"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -271,7 +271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66c2ef32-2918-4567-acce-ce9b5b2a97da
+      - 53eeb02a-2d7c-4a96-a9e1-b84983e20c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -282,19 +282,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:45.932800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1475"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -304,7 +304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f3566b0-068c-4db7-844a-998683ed65dc
+      - 19f46cb4-4d7d-44e9-af5a-e01c26aa81dd
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV2xUQ2pKTVdUTjRRVTFDTW1KQ1lVWjZOV3ByUW5WVk56bFdhMU12Y0dsdVREWk5SRkoxVDJrMlZ6TmlXblpRVkV4V1JUSlpka2cyV1N0bldYVktUV3BxYzBVS2VqUlJSM2hqTWt4NVlXRkdTR3BJV1RSM2FteGtlRUUwYzJaT2REVnlURlZGV2t3d01XcFBkR012U1d4dGJXTXJabkZOWjJsV2ExbDBSMVpxVEhKdWJncFhWR0ZsZG1wemMzaE9WRWxMZW5aaVpGRm9ObEU1WTFOR1JXVnhRakEyU1RnMU9HOUNXVTFFVmpWdFRUWlRVVFEwT0RFemIwTjBVWFpYTTJwb09GcHVDbmhuVm5oaVEzcEJZbGx3TVdrclRVWmpObEpDVG1wb2JERTVNRFJSVTBSb2JGbEVXRzFLZERGdWVqWmFNV1pVZEN0UVdIbEtRMUkzUlRGM1QwczNURUlLTlVOS2JIQjNPR3BOTTFacGMzRlRaM0ZWTUVOcmFYZGlhekI0TTJOeEwwdE9SVXNyY25aRU9XUXdaMjFQUzFFM1JWVm1XVXRFUkZSUU9EZHhhRFJXWkFwVFZWUjJWamRzZERaa1FuY3hORTUwV1hrd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWNUbHBWM2d4YjI0d1JWRlJUR3BFVnpoaFNuQkxVVzFvYWtwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlprMDBjRzVYTjBOUVFqUkVkeTlRU1Zwc1FscDFNR2RoT1VwU1JtazRUbFZLWTNwRWNtSTNSVkpWWkhGTVkxQmhkUW8wY1doVFIwOW9SRzVRVms1eGVUQldZV3hhVFV0VmFXcGhTMDk1WmpOMFZTOURiMHRwTUZsamNWZHFaWEpaWkZoQ2NGcFhMMmhCVVVNNFNWUlZUWE5rQ21kMlUwVnZNMjV2YW5Gd1pWaEtRMXBwUlRsaE5HeHdaWFpXYVdvNVJVdGhkR2x1UzI5Qlp6QlJSR1JqY1cxWVZreDJWekZ1Tms1dE5UQTJVeXRNV0hNS2VYUlBiMlozYjBsNFNFcG5TR0pIT0dkV1Z5OU1XalZRTW1KS01GSklTMlZSUVU5RlpVNTZLeTlsZFUwNVdWUXpZemR0Y2pKa0swUm5XbEV4Um1aVU1Rb3lRek5yZG5OT2F6WkRkR3hDUm1KM1owdGlTeTltVEdReE5saHBNVlZsZG1aM1JtNXVTamx5VGt4Q1FuQk9jVWRJVEU1SmRrbFZUVVJoT1VKTGJqRjVDblo1VnpKVFZYcG5jU3RFUVVJekt5OVBNREZYZFdkM1FsRlRjRGhXT1U0MEx6WndSUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRiZDc5MzctYmEyZS00Y2NlLTg2ZTUtNjdiZjliYjgyNTUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSSFM1MkRLWTBkQVE5Wkd0V1lPcUd3SkZKRTNFNjkyRU5GV2E4Vkh1UDJBUUNsU0lrWTFtNE44Mg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWFJpQ2xoQ09XcEZNbVJzU1d4WmJEa3pTRkIwZG5WUFpFZENhVFZpUmpoeVVIcEtNVTVRUVRsRmEzQXJSemRhYTBWWlZDdHJjMWxTTmt3dmRFeEpiemRLYzB3S1dqTklkVXRrZEVrdksyMUVZM296V2tnNWFHTnBiVEZ5YUVoQ1dtbHJhVzV1Y21aTFNqVk5VMFkxWTNCMmRVZEJWRXgyTDJSVUwxUnJlazFNVkZGb2FBcHNNVUpCVmtkTlRFSktiMWhzWVZoaGRVNXFURGhCSzBwbGJHOW1TMEZaT0dGRmNEbDFjRUl2TTFkNVUwUXZNelZWWmk5c1ZYZElkMlZuYTJOUk5WQm1Da2t5WVhCallXOTRlbkl6T0dFM1QwTlhXSE5NVDFGak5rcGFTVXBKTkV4cGMyOUNUREIzVEZwemNGcFFWVFJMUjBKR1ltRTJWRGxhUTNKWFNscGtibGNLTTBGTU1XNUxMMUp3Wm1oaFRHSlNTbTVsVjFBdk1pODVURVEwV0dkTVlrTnFNV3d5U21zelltaDVVM0UyTjFsQlNGWkhPSE5UWkdReWNUSmpLMU5rUXdwSlVraDFUV3AwUmxKNVYwdFhWMjg1ZFZkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVpUaDRZbGhRUTJsYVZXbE1la2RETjBka1oxbEdkamhKUVdkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFltZDJhVEJIV2pkMFZuaE9TRlpFWjFCUVNYcFhVRmN6YjBSMllVOTZNSEJJYkU1cmFscGxRV05RWVRNeVMwNUlTQXBtUlhscVpFTnZWMUp2TkU1NFpHODNNV2hTYmxZMFVVRkdTRVZvYUZCblNGWkRUakYyWTJGRVRFOXhaM0ZwTVUxc1FXTnJOelJCYkRKbVNEVTVWME5sQ2xSRVlrdDVWM3BEY2tWNlZ6WmxiV3BuYm1KS1kzWlNhamhzZFRsS1dtVlVUVXRqY3pSU1pteEVSMXBpUkVsM1lsZGtTMEpUWmpKS1dDdElORWw1TDBJS1VtMUxaR1ZwV21kNVNTODVkazlaVm1wU2RqZ3lRVGN2VFhSTFdXVnFjVmMwWms0NFRrdzVXVWg0ZVdKRFN6QTNRWFJXV0hoalUxZFRValJyVkV4QldRcGxNM0k0TWpCR09EUXlkVnBGVXpKSVNGTXhOMDVaTkVkeWVESjRZVkZPYWpsRGQyMTBSSGdyWmxsUmRuaDRORzlyZFZSTmNVSkpUeXRKYlU1Sk5GZFlDaTkwY0dod2NEZHlNVXR4YVRKb05EVlplRTlDUVhSRVpVeENObWhHYVZSUE5WSkxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZTE4YWI4MTUtZWU4My00ZWJlLWJhYzctZDM4MzA5ZjJlZTM0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqc1VRbzR3amlRNXZoQXloV1RzNXdLdTNXMVowbU14MFFTbDc3NnNDb0E5cFFDbm5FMTNWMTRJNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2684"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34d5cf80-1996-44f7-8129-b2cb5491219d
+      - 40fde841-2665-4bc6-a178-fd3a703bcca7
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:45.932800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1475"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc593085-2e93-41a5-b0fa-342d42eea0c1
+      - 47f2f7e0-8c5c-42a1-a0b2-14faf1d55615
     status: 200 OK
     code: 200
     duration: ""
@@ -383,19 +383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321315Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:17:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64d85293-9fcc-449f-a3ff-d8d593e94466
+      - 7314f10b-daec-47a4-955b-ac4758ca6ee8
     status: 200 OK
     code: 200
     duration: ""
@@ -416,19 +416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:17:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd27bdd4-1e13-4107-80ba-bd1d0815059c
+      - 2b421db9-8099-46d4-bba3-2a7c60647556
     status: 200 OK
     code: 200
     duration: ""
@@ -449,19 +449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:17:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 709f039f-ed93-4bcd-b16e-206f51242348
+      - 7af77617-f85e-4a93-89a1-4c0bcbfbed8c
     status: 200 OK
     code: 200
     duration: ""
@@ -482,19 +482,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:18:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3efc8e9-4a9e-4294-bd74-7d8680594e4b
+      - 00bc66d0-a08e-44e2-977f-7b851ccc93cf
     status: 200 OK
     code: 200
     duration: ""
@@ -515,19 +515,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:18:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bb15e2e-cdf6-4f17-8406-5abb7496bff2
+      - 3e342703-e96e-44e2-9a90-49b3dc90db0f
     status: 200 OK
     code: 200
     duration: ""
@@ -548,19 +548,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:18:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 175b6662-7b0d-4f6e-96ae-efbf9fb12b2b
+      - 1d69ce10-9f58-44ca-9f93-689310843229
     status: 200 OK
     code: 200
     duration: ""
@@ -581,19 +581,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:18:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 173b7a42-09d0-4989-b615-99a643708958
+      - 0f7c0db7-3a55-41dc-ab69-e2145fb7bc9e
     status: 200 OK
     code: 200
     duration: ""
@@ -614,19 +614,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:18:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe57be04-7c06-4ca2-8a0a-4ff19ca7cb53
+      - 284c828a-f37f-4c17-a144-48d90874b822
     status: 200 OK
     code: 200
     duration: ""
@@ -647,19 +647,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:36 GMT
+      - Fri, 10 Nov 2023 13:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b47eb7-3454-4d9f-ad0c-0b2e3783c079
+      - 335d3d1c-ff46-42fa-bf88-e06e1b79fbcc
     status: 200 OK
     code: 200
     duration: ""
@@ -680,19 +680,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:41 GMT
+      - Fri, 10 Nov 2023 13:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cb288fa-d49f-4f06-9376-51c64b51b4dd
+      - 2b601295-c9eb-4bf7-afbf-053ac744e18e
     status: 200 OK
     code: 200
     duration: ""
@@ -713,19 +713,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59684003-a0fc-43dc-a557-0d957f73e863
+      - 92e5f807-2a96-47e2-a5ef-26e0cc711191
     status: 200 OK
     code: 200
     duration: ""
@@ -746,19 +746,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:18:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66569817-6cc4-40b2-877c-86724a85a97a
+      - 24f5a518-3d55-4530-8ee4-2b3c1886cbea
     status: 200 OK
     code: 200
     duration: ""
@@ -779,19 +779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9877e95f-6627-4ef4-bb8c-41f13d9890de
+      - 6da05135-7344-4bde-b32d-c235886a39c9
     status: 200 OK
     code: 200
     duration: ""
@@ -812,19 +812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b8161c5-f693-4e7f-89d4-9f0691bd9319
+      - a6788610-380f-4a36-8185-0f593787033b
     status: 200 OK
     code: 200
     duration: ""
@@ -845,19 +845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c19c6cc-9ded-4ab0-b7e1-96b34339ed4f
+      - 800141b2-efb8-40c1-92ec-3585ad71448e
     status: 200 OK
     code: 200
     duration: ""
@@ -878,19 +878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:19:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99dbd641-989e-42d7-8ed0-c5d4fa2036f7
+      - c4e65142-2187-46ab-b74b-799afb984659
     status: 200 OK
     code: 200
     duration: ""
@@ -911,19 +911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:19:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef23c23c-0382-42fb-a0c2-ade88f660dc6
+      - 47804023-c363-4865-a113-5da4c31a8679
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:19:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd7dee32-1e64-41dd-88e9-41c712a2af62
+      - 6bb56a50-8e90-4a79-980a-86005abd3543
     status: 200 OK
     code: 200
     duration: ""
@@ -977,19 +977,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e958f21-3edd-43dd-9a68-703df0176f41
+      - 4a58ace0-47b2-46fb-95cc-b5902b7e5f5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,19 +1010,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:19:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8492bb7f-2b74-4fdc-82af-36bf54013b92
+      - 46cd14aa-46c5-4e10-ace5-a0b3a5bb40fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,19 +1043,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:19:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adcb368e-1e52-4fda-849b-6be9b3c98564
+      - 32783e01-e2c7-4c27-8d39-1cf008caa442
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,19 +1076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3f09a49-2346-4668-9ff6-b548e5380a58
+      - 29787a12-3f6f-4356-bd9a-81d7509ee30f
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22fb128e-02ae-4b39-92b5-c5c11e9b2761
+      - 7be0a325-32d3-4a8a-81a2-c281dfea81a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,19 +1142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 337fdbfd-8136-4e6d-aaba-a485be4b542c
+      - 35f8c17d-0cb1-47ad-ab59-b8a2eec84211
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,19 +1175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:19:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b25893c-7782-4a22-b3fc-f825b13059e9
+      - 854da318-e166-4a12-bc10-5e2ec9c4e4bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,19 +1208,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:19:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 646c7b41-ddc6-48fb-896a-30e4495833c2
+      - e05fc780-0a4c-4674-9d81-09b9abc7c032
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,19 +1241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:06 GMT
+      - Fri, 10 Nov 2023 13:19:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1263,7 +1263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92e2986f-a86c-48d8-acaf-b1318ab20401
+      - 3606c8ee-1869-4c4d-9f86-fa1c74f80341
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,19 +1274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef413512-59c5-41cb-9b93-58bf4ffd70fd
+      - a5896719-5ee0-461f-8bc2-7760756c13ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,19 +1307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3088236e-c051-4f8f-99d1-a7132d2a033b
+      - ff0faced-10ae-4a3b-a33c-0fafd6ee8bda
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,19 +1340,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d726092-b3e4-4295-a059-f7d7e9e5b21b
+      - 3fc93e27-e15e-4dac-8cb1-39cb8ec5c564
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,19 +1373,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6f76ba6-2b4e-44f8-9b8e-385a6d17a334
+      - aab6ea37-b551-4e9b-9135-963b5a7ce6fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,19 +1406,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2b98e20-32ce-4182-83fc-325cf9e8a1d0
+      - 81ffe3f3-5710-4b06-8213-19e55dab7a16
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,19 +1439,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe097abc-76bd-4ed3-bee6-3e62f46d6bac
+      - 3de8a3ef-f005-4d21-8200-c87be5ad9706
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,19 +1472,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4c473a6-72e4-48cb-86f3-81e66f9b256c
+      - 9e395c3a-4d84-48e0-892d-566c053dbdbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,19 +1505,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6e6fc52-dfc8-432b-81cf-797d629a5cef
+      - 4d75d3d0-1930-4b14-9c01-1cd6c457d6ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,19 +1538,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:20:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcb987e2-03d2-4eb2-a99c-240e7dc543d8
+      - a2bd34a4-1432-42ec-afdc-fb6e56107e58
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,19 +1571,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:20:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d164dec9-387f-44bc-ab52-e54f21467355
+      - f3067610-280e-4d4a-901e-a1fdf06d8965
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,19 +1604,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c6b7b82-02cb-4ba8-b2f7-9b9da0403d95
+      - 50d6629f-9e4c-4d55-a6dc-9b85110863a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,19 +1637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e5c642-56d9-4efb-924e-3cca274d9684
+      - cc4af108-5d56-4a83-b550-795b83526e28
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,19 +1670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1692,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec22621c-cdd6-4d48-8ae4-16ee795bdb98
+      - 526cfe56-d6a7-4038-b95d-9d7758632946
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,19 +1703,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:21:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1725,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31b02129-5a47-4e8b-b727-a93365f2bec9
+      - 72629811-efbc-4a6a-8963-e9f96cb27cc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,19 +1736,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:21:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1758,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0481f8d1-7ce8-4685-8b7e-90cd0f2fcb51
+      - 2a3e574d-29e6-480f-bab9-b58f5062428f
     status: 200 OK
     code: 200
     duration: ""
@@ -1769,19 +1769,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1791,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5afbeda-a38c-4e40-845b-6dd127df5f6c
+      - 59702aac-bc94-432e-b64e-baa661573fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1802,19 +1802,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:21:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1824,7 +1824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4b81d57-f77e-4f6a-a76c-0df96823bd54
+      - af3fbb18-e462-4718-89fa-2633e9d27dd5
     status: 200 OK
     code: 200
     duration: ""
@@ -1835,19 +1835,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:21:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1857,7 +1857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 799cf412-564e-498e-98c5-87ff245cfea2
+      - 16aa6c3b-8280-446f-af32-9a5260815b23
     status: 200 OK
     code: 200
     duration: ""
@@ -1868,19 +1868,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:21:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1890,7 +1890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 013e800a-cd38-409d-bba3-d16a92db8b02
+      - bc438917-3f2a-4c68-8df7-3fe089217ffc
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,19 +1901,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1923,7 +1923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d672eaf6-9e5d-45ea-93f5-c16af1c0c9e7
+      - 4ec0d1d1-e258-48d0-a699-a52ae4deb945
     status: 200 OK
     code: 200
     duration: ""
@@ -1934,19 +1934,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:21:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1956,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd366f94-b72f-4e99-b381-abd9f617119d
+      - 9e6619a7-ac52-4c51-bb1e-92d066a8d0ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1967,19 +1967,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:21:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1989,7 +1989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 589e1a3f-45e7-43c8-90a6-55f85cc9151a
+      - dcc5a514-455e-41e8-965b-63e3c0207f8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2000,19 +2000,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:21:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2022,7 +2022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29797c0e-0970-4ff0-9dbc-66099b47acca
+      - 00f267b7-92fd-4144-9b0f-20a3ab26e61a
     status: 200 OK
     code: 200
     duration: ""
@@ -2033,19 +2033,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:21:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2055,7 +2055,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c2fbbe6-2942-416a-90cc-a2c006e12c63
+      - d23d7144-8c45-41a1-a3b3-97ae9eea7f2b
     status: 200 OK
     code: 200
     duration: ""
@@ -2066,19 +2066,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2088,7 +2088,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af528f9a-ea47-4350-adea-d61fbe00488a
+      - 6ba38867-c8f0-4fac-83f5-0bc74d822a0e
     status: 200 OK
     code: 200
     duration: ""
@@ -2099,19 +2099,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:22:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2121,7 +2121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5db8eedc-2faa-4ac0-96e2-cc81d9bca8f8
+      - a3c00701-dd62-468c-a14e-615d5ea524af
     status: 200 OK
     code: 200
     duration: ""
@@ -2132,19 +2132,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:22:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2154,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f670894-5c27-4d52-a2ef-56e0063daa1d
+      - f60869dd-cbaa-4841-8349-08259e305b6d
     status: 200 OK
     code: 200
     duration: ""
@@ -2165,19 +2165,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:22:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2187,7 +2187,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6ae8243-8aa9-4a63-855b-169f6b0343cf
+      - 6debaec1-c184-450b-accc-ebc085b426ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2198,19 +2198,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:33 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2220,7 +2220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89797b1a-562f-434e-a69b-a0a1ffe277d3
+      - 94248efd-93cc-4bfa-a15b-f2e62dbaf54c
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,19 +2231,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:38 GMT
+      - Fri, 10 Nov 2023 13:22:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2253,7 +2253,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 444fa5c0-4805-4975-8c73-ea9247569a06
+      - d040b8a9-759e-42b8-8a04-76a08822440d
     status: 200 OK
     code: 200
     duration: ""
@@ -2264,19 +2264,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:43 GMT
+      - Fri, 10 Nov 2023 13:22:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2286,7 +2286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e644944-e05e-464a-a9f0-b11d1416357c
+      - 657a0f1b-ac03-485f-b70e-919a07bd33aa
     status: 200 OK
     code: 200
     duration: ""
@@ -2297,19 +2297,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2319,7 +2319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aabbc22-b5a7-49af-a1dd-f7f3ec06e161
+      - 8696d9ef-c0d2-46ca-866c-06501aa94c87
     status: 200 OK
     code: 200
     duration: ""
@@ -2330,19 +2330,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:49.805321Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:22:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2352,7 +2352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e47263fb-261e-4729-ad63-a4b01beed65e
+      - 856d6d35-f359-4471-bc70-b76c56267fd1
     status: 200 OK
     code: 200
     duration: ""
@@ -2363,19 +2363,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:43.795049Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2385,7 +2385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3782d3a9-f82d-4e86-803b-9881815f32e7
+      - da7c68e4-89e1-4d4b-be0f-8a36ee23f50a
     status: 200 OK
     code: 200
     duration: ""
@@ -2396,19 +2396,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:19:25.414176Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "592"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:03 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2418,7 +2418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b422672-c784-44a0-91f7-3e34182d238a
+      - ecd7f41c-77a8-4c7b-b68e-0a23e6fc669f
     status: 200 OK
     code: 200
     duration: ""
@@ -2429,19 +2429,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:43.795049Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:08 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2451,7 +2451,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7890c272-9254-418f-bf06-96751f7f30eb
+      - 60c77743-ffd3-4217-aac2-1013683aa9e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2462,19 +2462,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/nodes?order_by=created_at_asc&page=1&pool_id=7a52bea8-c6c2-488b-b862-69cd40b132fb&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:49.388335Z","error_message":null,"id":"820af0ac-007e-400d-b856-87e81a7bfd56","name":"scw-test-k8s-private-network-pool-820af0ac007e","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/d2b80a20-6488-4d84-b9c2-830f42da3c57","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.726330Z"},{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:53.487260Z","error_message":null,"id":"83aff596-aac4-4a1d-9103-490deb1f720a","name":"scw-test-k8s-private-network-pool-83aff596aac4","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.744750Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "592"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2484,7 +2484,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51902418-b210-4c1f-b374-5f8a0a1c3888
+      - 237a07dc-aead-45a9-9544-6c48054ca162
     status: 200 OK
     code: 200
     duration: ""
@@ -2495,19 +2495,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:19:25.414176Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "592"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:18 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2517,7 +2517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57c4c443-0e68-4a18-8346-f4d16481f6d0
+      - 013abbe3-30cb-47af-a42a-7958e622fc7c
     status: 200 OK
     code: 200
     duration: ""
@@ -2528,19 +2528,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3ad9e923-b5ae-4680-b796-7d4a3cd12b96
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:17:42.602847Z","dhcp_enabled":true,"id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:42.602847Z","id":"3270d81e-9182-44bf-9a3d-f1406419d094","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:17:42.602847Z"},{"created_at":"2023-11-10T13:17:42.602847Z","id":"296f03bb-e3ae-4461-8593-beb5fd2f5374","subnet":"fd63:256c:45f7:e86::/64","updated_at":"2023-11-10T13:17:42.602847Z"}],"tags":[],"updated_at":"2023-11-10T13:17:42.602847Z","vpc_id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c"}'
     headers:
       Content-Length:
-      - "592"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:23 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2550,7 +2550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15f7bb86-b624-438b-a316-28405a8fa04c
+      - 55fbfc14-6b92-4518-a745-543daeb919a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2561,19 +2561,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:43.795049Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2583,7 +2583,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 272d6bf7-b449-447c-bf29-d61c56189cab
+      - 36e3ff51-db21-464d-a9a4-f24017bff8a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2594,19 +2594,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:19:25.414176Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "592"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:34 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2616,7 +2616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde9e8c8-82d7-4971-ba1b-5fc0610166b4
+      - 417deae4-995c-4605-a46f-0ef21d8bfcb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/nodes?order_by=created_at_asc&pool_id=7a52bea8-c6c2-488b-b862-69cd40b132fb&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:49.388335Z","error_message":null,"id":"820af0ac-007e-400d-b856-87e81a7bfd56","name":"scw-test-k8s-private-network-pool-820af0ac007e","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/d2b80a20-6488-4d84-b9c2-830f42da3c57","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.726330Z"},{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:53.487260Z","error_message":null,"id":"83aff596-aac4-4a1d-9103-490deb1f720a","name":"scw-test-k8s-private-network-pool-83aff596aac4","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.744750Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "592"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:39 GMT
+      - Fri, 10 Nov 2023 13:22:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f68de61e-d7df-4baf-96c4-5cdd8f3aa1d0
+      - e7e96b0b-9351-493c-8472-85367d8babaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,1046 +2660,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b99f9acb-5d27-4b3d-98d9-7ee6620c90e8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f7ad3c1-79fe-4672-9e07-8aa23c36ae01
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d9c0b92-18e9-4377-8cec-483f13046bc9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cdec75fc-b72a-403c-b261-42b7ec7dc98e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b64457aa-b007-4150-8b17-da46c7f0a748
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9af2c9aa-e71a-489a-b531-ee6672883660
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f5c54d6-86b7-48ac-b9d8-76f6c49b854b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f17177c-72ef-4e92-a435-e3c6811727f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b5d6fa9-8c6b-4e52-bc57-542ee9aeb7cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 231a7487-426d-4520-8c15-917b37fb4fc5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f16a760-c4a9-41ab-ae09-120bf75062f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 05d88af3-63f3-4405-b14e-51ec03e1afcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83c0ae87-87ca-44aa-846c-2d4d799f3564
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09bd49a4-7ec7-42da-b09f-d5f8f1b0addb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:56:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 50d37572-ca8e-4d02-b7c3-af84328a0b8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 825bd2d2-fd23-4423-aeaf-e4bd5d140481
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a740842-79aa-4f00-a8e5-ef5eda900601
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94be632b-c2e1-44e8-ae6d-b0d26434b92b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d7eba0f-9cd9-4bfd-a7cb-75fadbe6e592
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 56ee87c5-937a-4f6b-98c9-8101f836a7d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c95172fe-165b-48e9-b15c-173dc3d6a5fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "592"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81455ae5-342f-4788-9260-824cce84ec0c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "590"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ffc7a864-08e7-492c-86c2-27fe04f5ed0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 105ac38e-6236-47d4-bb4d-ec3ffe102bfc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "590"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33d5f74f-5c52-4d46-bc24-2931f128ca7e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&page=1&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1258"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70c07760-69ae-4453-830c-63949da2f1af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f45bfe10-ece7-45fa-837e-ce944400632a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
-    headers:
-      Content-Length:
-      - "708"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5ca4a484-9995-4564-a7d9-2545f18f3eb7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "590"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0662859d-05ab-4020-852b-e213f789440d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ec241a9-f400-43d1-8f2d-3abe987efca6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1258"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:57:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c904eeaa-f7e4-472b-885c-95b3da61cb1a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f39671eb-2054-4775-848e-780dec2c4f52
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2b80a20-6488-4d84-b9c2-830f42da3c57
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T15:55:03.583869+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-1254a3f87ee7","id":"f39671eb-2054-4775-848e-780dec2c4f52","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:63c:301::1","gateway":"2001:bc8:63c:301::","netmask":"64"},"location":{"cluster_id":"29","hypervisor_id":"202","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:67","maintenances":[],"modification_date":"2023-11-07T15:55:19.588328+00:00","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.66.74.195","private_nics":[{"creation_date":"2023-11-07T15:55:04.358912+00:00","id":"c234dda7-8eed-4fea-a5e3-6b469256fd2a","mac_address":"02:00:00:14:a3:f9","modification_date":"2023-11-07T15:55:05.146548+00:00","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","server_id":"f39671eb-2054-4775-848e-780dec2c4f52","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.138.73","dynamic":true,"family":"inet","gateway":null,"id":"f696e00b-1234-42a6-a328-a9ff5b25ac02","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.138.73","dynamic":true,"family":"inet","gateway":null,"id":"f696e00b-1234-42a6-a328-a9ff5b25ac02","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e0f0232a-0b28-4673-8992-26f2e07dba55","name":"kubernetes
-      54bd7937-ba2e-4cce-86e5-67bf9bb82553"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=54bd7937-ba2e-4cce-86e5-67bf9bb82553","pool=7d41f060-d78c-497d-8412-77dcd41e5073","pool-name=pool","runtime=containerd","managed=true","node=1254a3f8-7ee7-4310-95dc-be2e6cea124b"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T15:55:03.583869+00:00","export_uri":null,"id":"9677b7d9-30a4-42ba-b2d0-908c6227f974","modification_date":"2023-11-07T15:55:03.583869+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f39671eb-2054-4775-848e-780dec2c4f52","name":"scw-test-k8s-private-network-pool-1254a3f87ee7"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:19:50.111164+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-820af0ac007e","id":"d2b80a20-6488-4d84-b9c2-830f42da3c57","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4750:1e06::1","gateway":"2001:bc8:4750:1e06::","netmask":"64"},"location":{"cluster_id":"5","hypervisor_id":"1601","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:43","maintenances":[],"modification_date":"2023-11-10T13:20:06.608290+00:00","name":"scw-test-k8s-private-network-pool-820af0ac007e","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.175.141","private_nics":[{"creation_date":"2023-11-10T13:19:50.608872+00:00","id":"5631ea55-b9ae-4178-b445-1d87baacf731","mac_address":"02:00:00:14:b3:b8","modification_date":"2023-11-10T13:19:51.339548+00:00","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","server_id":"d2b80a20-6488-4d84-b9c2-830f42da3c57","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.158.124.49","dynamic":true,"family":"inet","gateway":null,"id":"aedf18d3-8492-404a-9deb-549f192a686c","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.124.49","dynamic":true,"family":"inet","gateway":null,"id":"aedf18d3-8492-404a-9deb-549f192a686c","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"704fa895-4414-4231-863a-3ed89d86eebd","name":"kubernetes
+      e18ab815-ee83-4ebe-bac7-d38309f2ee34"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=e18ab815-ee83-4ebe-bac7-d38309f2ee34","pool=7a52bea8-c6c2-488b-b862-69cd40b132fb","pool-name=pool","runtime=containerd","managed=true","node=820af0ac-007e-400d-b856-87e81a7bfd56"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:19:50.111164+00:00","export_uri":null,"id":"01fb87c2-208e-4a2b-8285-4c40e935300c","modification_date":"2023-11-10T13:19:50.111164+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"d2b80a20-6488-4d84-b9c2-830f42da3c57","name":"scw-test-k8s-private-network-pool-820af0ac007e"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3952"
+      - "3955"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:36 GMT
+      - Fri, 10 Nov 2023 13:22:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3709,7 +2686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ff78021-5de3-44b8-b054-501a47931b59
+      - bad812f4-9cb4-4fd8-9407-32963f644b01
     status: 200 OK
     code: 200
     duration: ""
@@ -3720,23 +2697,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b5b8cd51-72c2-461d-b62b-97e97ca383a4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T15:55:07.434620+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-0a5747233b4a","id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:8703::1","gateway":"2001:bc8:610:8703::","netmask":"64"},"location":{"cluster_id":"52","hypervisor_id":"501","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:69","maintenances":[],"modification_date":"2023-11-07T15:55:22.791944+00:00","name":"scw-test-k8s-private-network-pool-0a5747233b4a","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.194.88.135","private_nics":[{"creation_date":"2023-11-07T15:55:07.977875+00:00","id":"24c79171-2295-4182-a104-fa2e44b443df","mac_address":"02:00:00:14:a3:fa","modification_date":"2023-11-07T15:55:08.801885+00:00","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","server_id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.177.183","dynamic":true,"family":"inet","gateway":null,"id":"7fd94e15-665d-4d53-b7d1-a50f35453ced","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.177.183","dynamic":true,"family":"inet","gateway":null,"id":"7fd94e15-665d-4d53-b7d1-a50f35453ced","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e0f0232a-0b28-4673-8992-26f2e07dba55","name":"kubernetes
-      54bd7937-ba2e-4cce-86e5-67bf9bb82553"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=54bd7937-ba2e-4cce-86e5-67bf9bb82553","pool=7d41f060-d78c-497d-8412-77dcd41e5073","pool-name=pool","runtime=containerd","managed=true","node=0a574723-3b4a-4a67-a239-5dd1cf6a3655"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T15:55:07.434620+00:00","export_uri":null,"id":"2740b4d4-8560-43ac-a524-4db1b4987691","modification_date":"2023-11-07T15:55:07.434620+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","name":"scw-test-k8s-private-network-pool-0a5747233b4a"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:19:53.853085+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-83aff596aac4","id":"8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4748:c05::1","gateway":"2001:bc8:4748:c05::","netmask":"64"},"location":{"cluster_id":"3","hypervisor_id":"701","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:47","maintenances":[],"modification_date":"2023-11-10T13:20:12.326572+00:00","name":"scw-test-k8s-private-network-pool-83aff596aac4","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.151.11","private_nics":[{"creation_date":"2023-11-10T13:19:54.401358+00:00","id":"95dce732-bed2-450d-90ac-ce9feaf2a628","mac_address":"02:00:00:14:b3:ba","modification_date":"2023-11-10T13:19:55.293101+00:00","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","server_id":"8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.164.36","dynamic":true,"family":"inet","gateway":null,"id":"56524145-6f45-47eb-a301-46ecb9edc884","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.164.36","dynamic":true,"family":"inet","gateway":null,"id":"56524145-6f45-47eb-a301-46ecb9edc884","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"704fa895-4414-4231-863a-3ed89d86eebd","name":"kubernetes
+      e18ab815-ee83-4ebe-bac7-d38309f2ee34"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=e18ab815-ee83-4ebe-bac7-d38309f2ee34","pool=7a52bea8-c6c2-488b-b862-69cd40b132fb","pool-name=pool","runtime=containerd","managed=true","node=83aff596-aac4-4a1d-9103-490deb1f720a"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:19:53.853085+00:00","export_uri":null,"id":"c945afc0-b4fc-489e-a797-3844712cadd6","modification_date":"2023-11-10T13:19:53.853085+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","name":"scw-test-k8s-private-network-pool-83aff596aac4"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3957"
+      - "3953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:36 GMT
+      - Fri, 10 Nov 2023 13:22:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3746,7 +2723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61535e8b-dc92-4e54-8598-b704f0a34713
+      - 56df539d-b1c8-4abc-9673-0a1dfa30973c
     status: 200 OK
     code: 200
     duration: ""
@@ -3757,19 +2734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
+    body: '{"created_at":"2023-11-10T13:17:42.343618Z","id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":1,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-11-10T13:17:42.343618Z"}'
     headers:
       Content-Length:
-      - "347"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3779,7 +2756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd24f155-eeee-44db-8613-51f8b09fee7d
+      - a13f49b5-dbea-41e9-981e-970a4807f86e
     status: 200 OK
     code: 200
     duration: ""
@@ -3790,19 +2767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3ad9e923-b5ae-4680-b796-7d4a3cd12b96
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
+    body: '{"created_at":"2023-11-10T13:17:42.602847Z","dhcp_enabled":true,"id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:42.602847Z","id":"3270d81e-9182-44bf-9a3d-f1406419d094","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:17:42.602847Z"},{"created_at":"2023-11-10T13:17:42.602847Z","id":"296f03bb-e3ae-4461-8593-beb5fd2f5374","subnet":"fd63:256c:45f7:e86::/64","updated_at":"2023-11-10T13:17:42.602847Z"}],"tags":[],"updated_at":"2023-11-10T13:17:42.602847Z","vpc_id":"09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c"}'
     headers:
       Content-Length:
-      - "708"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3812,7 +2789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c17cd4cc-d23f-455c-b861-c8676b10658b
+      - da2460f9-a308-4d95-96a9-04b892794a28
     status: 200 OK
     code: 200
     duration: ""
@@ -3823,19 +2800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:19:25.414176Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3845,7 +2822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed35fc78-9163-41be-be8b-4ab46c132f3e
+      - 92d60c26-a61a-42a2-bd4b-4e7c154ddfaf
     status: 200 OK
     code: 200
     duration: ""
@@ -3856,19 +2833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV2xUQ2pKTVdUTjRRVTFDTW1KQ1lVWjZOV3ByUW5WVk56bFdhMU12Y0dsdVREWk5SRkoxVDJrMlZ6TmlXblpRVkV4V1JUSlpka2cyV1N0bldYVktUV3BxYzBVS2VqUlJSM2hqTWt4NVlXRkdTR3BJV1RSM2FteGtlRUUwYzJaT2REVnlURlZGV2t3d01XcFBkR012U1d4dGJXTXJabkZOWjJsV2ExbDBSMVpxVEhKdWJncFhWR0ZsZG1wemMzaE9WRWxMZW5aaVpGRm9ObEU1WTFOR1JXVnhRakEyU1RnMU9HOUNXVTFFVmpWdFRUWlRVVFEwT0RFemIwTjBVWFpYTTJwb09GcHVDbmhuVm5oaVEzcEJZbGx3TVdrclRVWmpObEpDVG1wb2JERTVNRFJSVTBSb2JGbEVXRzFLZERGdWVqWmFNV1pVZEN0UVdIbEtRMUkzUlRGM1QwczNURUlLTlVOS2JIQjNPR3BOTTFacGMzRlRaM0ZWTUVOcmFYZGlhekI0TTJOeEwwdE9SVXNyY25aRU9XUXdaMjFQUzFFM1JWVm1XVXRFUkZSUU9EZHhhRFJXWkFwVFZWUjJWamRzZERaa1FuY3hORTUwV1hrd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWNUbHBWM2d4YjI0d1JWRlJUR3BFVnpoaFNuQkxVVzFvYWtwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlprMDBjRzVYTjBOUVFqUkVkeTlRU1Zwc1FscDFNR2RoT1VwU1JtazRUbFZLWTNwRWNtSTNSVkpWWkhGTVkxQmhkUW8wY1doVFIwOW9SRzVRVms1eGVUQldZV3hhVFV0VmFXcGhTMDk1WmpOMFZTOURiMHRwTUZsamNWZHFaWEpaWkZoQ2NGcFhMMmhCVVVNNFNWUlZUWE5rQ21kMlUwVnZNMjV2YW5Gd1pWaEtRMXBwUlRsaE5HeHdaWFpXYVdvNVJVdGhkR2x1UzI5Qlp6QlJSR1JqY1cxWVZreDJWekZ1Tms1dE5UQTJVeXRNV0hNS2VYUlBiMlozYjBsNFNFcG5TR0pIT0dkV1Z5OU1XalZRTW1KS01GSklTMlZSUVU5RlpVNTZLeTlsZFUwNVdWUXpZemR0Y2pKa0swUm5XbEV4Um1aVU1Rb3lRek5yZG5OT2F6WkRkR3hDUm1KM1owdGlTeTltVEdReE5saHBNVlZsZG1aM1JtNXVTamx5VGt4Q1FuQk9jVWRJVEU1SmRrbFZUVVJoT1VKTGJqRjVDblo1VnpKVFZYcG5jU3RFUVVJekt5OVBNREZYZFdkM1FsRlRjRGhXT1U0MEx6WndSUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRiZDc5MzctYmEyZS00Y2NlLTg2ZTUtNjdiZjliYjgyNTUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSSFM1MkRLWTBkQVE5Wkd0V1lPcUd3SkZKRTNFNjkyRU5GV2E4Vkh1UDJBUUNsU0lrWTFtNE44Mg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWFJpQ2xoQ09XcEZNbVJzU1d4WmJEa3pTRkIwZG5WUFpFZENhVFZpUmpoeVVIcEtNVTVRUVRsRmEzQXJSemRhYTBWWlZDdHJjMWxTTmt3dmRFeEpiemRLYzB3S1dqTklkVXRrZEVrdksyMUVZM296V2tnNWFHTnBiVEZ5YUVoQ1dtbHJhVzV1Y21aTFNqVk5VMFkxWTNCMmRVZEJWRXgyTDJSVUwxUnJlazFNVkZGb2FBcHNNVUpCVmtkTlRFSktiMWhzWVZoaGRVNXFURGhCSzBwbGJHOW1TMEZaT0dGRmNEbDFjRUl2TTFkNVUwUXZNelZWWmk5c1ZYZElkMlZuYTJOUk5WQm1Da2t5WVhCallXOTRlbkl6T0dFM1QwTlhXSE5NVDFGak5rcGFTVXBKTkV4cGMyOUNUREIzVEZwemNGcFFWVFJMUjBKR1ltRTJWRGxhUTNKWFNscGtibGNLTTBGTU1XNUxMMUp3Wm1oaFRHSlNTbTVsVjFBdk1pODVURVEwV0dkTVlrTnFNV3d5U21zelltaDVVM0UyTjFsQlNGWkhPSE5UWkdReWNUSmpLMU5rUXdwSlVraDFUV3AwUmxKNVYwdFhWMjg1ZFZkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVpUaDRZbGhRUTJsYVZXbE1la2RETjBka1oxbEdkamhKUVdkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFltZDJhVEJIV2pkMFZuaE9TRlpFWjFCUVNYcFhVRmN6YjBSMllVOTZNSEJJYkU1cmFscGxRV05RWVRNeVMwNUlTQXBtUlhscVpFTnZWMUp2TkU1NFpHODNNV2hTYmxZMFVVRkdTRVZvYUZCblNGWkRUakYyWTJGRVRFOXhaM0ZwTVUxc1FXTnJOelJCYkRKbVNEVTVWME5sQ2xSRVlrdDVWM3BEY2tWNlZ6WmxiV3BuYm1KS1kzWlNhamhzZFRsS1dtVlVUVXRqY3pSU1pteEVSMXBpUkVsM1lsZGtTMEpUWmpKS1dDdElORWw1TDBJS1VtMUxaR1ZwV21kNVNTODVkazlaVm1wU2RqZ3lRVGN2VFhSTFdXVnFjVmMwWms0NFRrdzVXVWg0ZVdKRFN6QTNRWFJXV0hoalUxZFRValJyVkV4QldRcGxNM0k0TWpCR09EUXlkVnBGVXpKSVNGTXhOMDVaTkVkeWVESjRZVkZPYWpsRGQyMTBSSGdyWmxsUmRuaDRORzlyZFZSTmNVSkpUeXRKYlU1Sk5GZFlDaTkwY0dod2NEZHlNVXR4YVRKb05EVlplRTlDUVhSRVpVeENObWhHYVZSUE5WSkxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZTE4YWI4MTUtZWU4My00ZWJlLWJhYzctZDM4MzA5ZjJlZTM0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqc1VRbzR3amlRNXZoQXloV1RzNXdLdTNXMVowbU14MFFTbDc3NnNDb0E5cFFDbm5FMTNWMTRJNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2684"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +2855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d114deeb-b31e-4c5a-815e-7b8d1b4168d1
+      - 4b5522ba-4436-46c8-8205-da931bdc1bbe
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,19 +2866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:43.795049Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "590"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3911,7 +2888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d00a1c4-1437-4c88-bf8f-dd845eb1241a
+      - 6f6ac8db-9f3c-4cfc-a365-0558dc3172c4
     status: 200 OK
     code: 200
     duration: ""
@@ -3922,19 +2899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&page=1&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34/nodes?order_by=created_at_asc&page=1&pool_id=7a52bea8-c6c2-488b-b862-69cd40b132fb&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:49.388335Z","error_message":null,"id":"820af0ac-007e-400d-b856-87e81a7bfd56","name":"scw-test-k8s-private-network-pool-820af0ac007e","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/d2b80a20-6488-4d84-b9c2-830f42da3c57","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.726330Z"},{"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:53.487260Z","error_message":null,"id":"83aff596-aac4-4a1d-9103-490deb1f720a","name":"scw-test-k8s-private-network-pool-83aff596aac4","pool_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","provider_id":"scaleway://instance/fr-par-1/8f1b5bb9-e8e5-47dc-8f89-ecb853d345d0","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:43.744750Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1258"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:37 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3944,7 +2921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58bc94ec-8969-46b3-977c-91fefddada2a
+      - 3456e1fa-58a7-40f1-b2bc-4f8d7c4318b1
     status: 200 OK
     code: 200
     duration: ""
@@ -3955,19 +2932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239436596Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388636687Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "596"
+      - "619"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:38 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3977,7 +2954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0071ae2-4f02-4b1f-9f49-e54086d8e99b
+      - e9381161-e46a-4337-823a-f22761cd75fc
     status: 200 OK
     code: 200
     duration: ""
@@ -3988,19 +2965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:38 GMT
+      - Fri, 10 Nov 2023 13:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4010,7 +2987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00a6bfd0-f7db-4463-bc14-e278993747e1
+      - 76ebd0d9-89be-46ff-a8b6-09773c0150bb
     status: 200 OK
     code: 200
     duration: ""
@@ -4021,19 +2998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:43 GMT
+      - Fri, 10 Nov 2023 13:22:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4043,7 +3020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02eedc09-fe6c-41d9-addc-492765079b64
+      - 051ad291-25fc-4c21-828c-f85bb7f7f1bc
     status: 200 OK
     code: 200
     duration: ""
@@ -4054,19 +3031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:48 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4076,7 +3053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e895c1cf-5412-4666-b6bc-6f9033fcfe6d
+      - e62b0b25-11db-495f-bf34-21237012a9fd
     status: 200 OK
     code: 200
     duration: ""
@@ -4087,19 +3064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:53 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4109,7 +3086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1779474e-52cc-45b0-89dc-65c479d3a2b4
+      - a78a8b18-0582-4e60-8bdd-37ed247f4558
     status: 200 OK
     code: 200
     duration: ""
@@ -4120,10 +3097,175 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"7d41f060-d78c-497d-8412-77dcd41e5073","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 891ccfa5-52d6-4ddd-9a0a-162bcff529b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ad54b91-7319-4ead-a55e-f5d5592b2f7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d31d407f-3c4b-47a5-868f-18d80bda6d44
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37f8e8b3-61a5-4a9c-9b3a-710e603c37cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","container_runtime":"containerd","created_at":"2023-11-10T13:17:49.795890Z","id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:51.388637Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92bd2d1a-1479-43e9-b926-aa167d41df5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4132,7 +3274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:58 GMT
+      - Fri, 10 Nov 2023 13:23:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4142,7 +3284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc1142a5-8ae0-43e1-b656-e9153307e8f8
+      - 9eaf7363-1ca9-41ed-bd64-ff5ed3ec13a1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4153,19 +3295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055337Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:23:37.021705871Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:58 GMT
+      - Fri, 10 Nov 2023 13:23:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4175,7 +3317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c8841df-7e98-41e1-b1c4-bc0efb3cd824
+      - a55a1437-5795-4404-96d3-7d946df9533d
     status: 200 OK
     code: 200
     duration: ""
@@ -4186,19 +3328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:23:37.021706Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:58 GMT
+      - Fri, 10 Nov 2023 13:23:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4208,7 +3350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a8386be-22b8-41a8-b151-ec4466edc33a
+      - 01c4f90b-a03c-45a5-b4ba-d970787847b0
     status: 200 OK
     code: 200
     duration: ""
@@ -4219,19 +3361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:23:37.021706Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:03 GMT
+      - Fri, 10 Nov 2023 13:23:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4241,7 +3383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb814ed3-a405-4642-8141-1a2e178e3c09
+      - a2fbcf95-4838-4dfc-81d7-72bf39ec98a1
     status: 200 OK
     code: 200
     duration: ""
@@ -4252,10 +3394,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e18ab815-ee83-4ebe-bac7-d38309f2ee34.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:44.019604Z","created_at":"2023-11-10T13:17:44.019604Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e18ab815-ee83-4ebe-bac7-d38309f2ee34.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:23:37.021706Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7a46836-523a-452a-b4bb-62bd3d30e4a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4264,7 +3439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:08 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4274,7 +3449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eee372b2-5cca-4d87-b5ec-d9d10d370930
+      - f924b6c3-ab6c-437a-ada9-ada46d414f87
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4285,10 +3460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3ad9e923-b5ae-4680-b796-7d4a3cd12b96
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4297,7 +3472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:08 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4307,7 +3482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b31d5c5-33d1-4ef8-8e60-d36340419171
+      - dc960c89-9f60-4301-8fd9-b099078bc5b1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4318,7 +3493,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/09b6d4a9-e4aa-4b14-a106-3ba9b5e8596c
     method: DELETE
   response:
     body: ""
@@ -4328,7 +3503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:08 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fba17d2f-fb7f-4b22-850a-0c87b4a3b339
+      - e4063f60-9b74-41b1-9406-c3a176686f79
     status: 204 No Content
     code: 204
     duration: ""
@@ -4349,19 +3524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3ad9e923-b5ae-4680-b796-7d4a3cd12b96
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3ad9e923-b5ae-4680-b796-7d4a3cd12b96","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:08 GMT
+      - Fri, 10 Nov 2023 13:23:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,7 +3546,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4de9daa4-bd35-4ab1-aa33-dd27655a7f27
+      - ca9572fc-5cb3-4d1e-8eb8-91308851c764
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e18ab815-ee83-4ebe-bac7-d38309f2ee34
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e18ab815-ee83-4ebe-bac7-d38309f2ee34","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a65fcc1-1b3f-4564-9d4f-a008017bbbf1
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7a52bea8-c6c2-488b-b862-69cd40b132fb
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7a52bea8-c6c2-488b-b862-69cd40b132fb","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c989250e-7635-4863-b97b-18b24aff9ba3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:39 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 419c7efb-c087-4d54-9450-3d3fc6ba1505
+      - acd5ee4e-0ff3-4afe-9662-60d3ae11da63
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-public-ip","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-k8s-public-ip","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:41 GMT
+      - Fri, 10 Nov 2023 13:17:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce62c3de-9fb2-4de3-859b-89a6a5152101
+      - 28165b32-a9d4-4348-aa44-c4d3638c624d
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:41 GMT
+      - Fri, 10 Nov 2023 13:17:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5a6fb9c-3dc0-458f-af92-b9256b9e6b1b
+      - e978506e-7cab-4cd2-95c2-702343f13abf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253477Z","created_at":"2023-11-07T16:05:42.404253477Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:42.416427990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361150Z","created_at":"2023-11-10T13:17:42.433361150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:42.486698803Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:42 GMT
+      - Fri, 10 Nov 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8e600fd-4e08-4d6d-b26e-53c7db3ccd75
+      - b63151c0-2f3b-4262-a1f1-3184263f6d5b
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:42.416428Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:42.486699Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:42 GMT
+      - Fri, 10 Nov 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d289b0a-05a0-4330-b399-010019e87d82
+      - 0eb0ec7c-08ab-4957-99a1-42f2e783ff68
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:47 GMT
+      - Fri, 10 Nov 2023 13:17:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c394447-1584-45ea-bb9b-dbdaf705de30
+      - a0420261-ccda-4617-a3f8-079ab646a780
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:47 GMT
+      - Fri, 10 Nov 2023 13:17:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eac8c67-8da4-4b54-9c1b-16bb1171613e
+      - d2606e37-8996-4696-a7c9-e92d74a67852
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:47 GMT
+      - Fri, 10 Nov 2023 13:17:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9368fb0b-159b-4ee0-8f92-a9db635fec30
+      - ccd96a6e-4f84-4921-aa4b-32a038a9922a
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:47 GMT
+      - Fri, 10 Nov 2023 13:17:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4998cac5-58b4-4ab0-ae38-e18f94241588
+      - d9619d8f-3f00-4100-a125-c7a080158437
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919131802Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512107808Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "609"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:48 GMT
+      - Fri, 10 Nov 2023 13:17:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ce8b58-2752-49ef-9e41-892a3783627d
+      - a128f68f-cda9-450d-a1b9-a6e60253be9d
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:48 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee569efb-ed11-4186-a408-c79baf07ae6f
+      - 23949030-a16d-4bbb-bff8-a9a520516f94
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:53 GMT
+      - Fri, 10 Nov 2023 13:17:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e626049-7c2d-4516-8cff-27a3b43507dc
+      - 897c5862-0b53-4ffe-8fdf-bd03d87cb85c
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:05:58 GMT
+      - Fri, 10 Nov 2023 13:17:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e532aada-68c9-46b0-b7de-c73b409a1235
+      - 35f96cab-cc20-4564-aec6-81b6e80c4dea
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:03 GMT
+      - Fri, 10 Nov 2023 13:18:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9821010-7a1d-4fc7-ab9b-7835ac52c823
+      - 46d1f55c-7e70-45f3-a205-5891f3dd6495
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:08 GMT
+      - Fri, 10 Nov 2023 13:18:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6ebc1f-c2c7-41c4-8fb2-e81709027b11
+      - 6735d5a7-a6fd-45fd-9b30-cbbb0b248596
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:13 GMT
+      - Fri, 10 Nov 2023 13:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 686427e0-8ade-467e-baec-6377bc6b3119
+      - 023985f0-ae20-4ea4-bd36-dd7c550d25bd
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:18 GMT
+      - Fri, 10 Nov 2023 13:18:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d7048a3-3aec-4890-862f-cf466734aaee
+      - e1ccc2e1-47c7-4571-a402-9e8bfdd8eb01
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:23 GMT
+      - Fri, 10 Nov 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ca4f690-d18d-44c1-94c2-126c38c93cfe
+      - c4d4df98-0bd1-4057-b84b-20b2a31886ff
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:28 GMT
+      - Fri, 10 Nov 2023 13:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afc0d08f-873f-4b8a-8b82-e3072c7cc71e
+      - a8d106e2-5a70-4312-b1d9-330d35052ced
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:33 GMT
+      - Fri, 10 Nov 2023 13:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4a782f4-ec24-477e-9b20-5f1d2638056f
+      - ac2a0ad9-90e0-4cf8-8a63-e5a1d6cb60c2
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:38 GMT
+      - Fri, 10 Nov 2023 13:18:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3735b6b-6219-4451-a4bc-4fdf5677a88b
+      - 6320cd69-d736-4c56-b74e-f79e4f0a647e
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:43 GMT
+      - Fri, 10 Nov 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ae7c87b-b9bf-453d-b237-f39d9048228c
+      - fb3ee496-c538-45bd-b192-485777267b30
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:48 GMT
+      - Fri, 10 Nov 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dc4c0eb-4613-41b7-8868-7abc4ff2d350
+      - f739e59d-96b1-44e2-85a1-011dae760dfb
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:54 GMT
+      - Fri, 10 Nov 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9b6a47d-f2c9-44b0-bc30-785b8d90959b
+      - bdbff53f-d923-4615-9244-8c9d079ee50e
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:06:59 GMT
+      - Fri, 10 Nov 2023 13:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08688e99-999c-44ae-8297-dbba4794c854
+      - ae74532e-c01e-4775-8e69-204b104d7774
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:04 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f273a62-0f0e-47ee-aee3-087b9e2ea632
+      - 34e724de-b012-4fdb-8bfe-01c3cff63f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:09 GMT
+      - Fri, 10 Nov 2023 13:19:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c8aa19-b4f2-4264-bc3f-7c9b408fee38
+      - c3a59f21-1ba1-45a1-a1b8-cd3be5a863b7
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:14 GMT
+      - Fri, 10 Nov 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89cf4418-17d8-4a8e-9f59-310fa75c3429
+      - 5f80a5e2-eec1-41fd-8e41-5032d08ea557
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:19 GMT
+      - Fri, 10 Nov 2023 13:19:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 882b5857-896d-4069-97f2-6c5da3891e95
+      - acc1382f-754b-40d7-9b6d-056d8b4784e9
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:24 GMT
+      - Fri, 10 Nov 2023 13:19:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb06b0c6-96b9-4376-ada4-0364357a3280
+      - 10f930d0-cbf0-4895-addd-f109b4343778
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:29 GMT
+      - Fri, 10 Nov 2023 13:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6461a01a-0ce5-4dbf-a62f-87f8496ba3fb
+      - bf9a9010-27f4-40e2-ba96-dffc96b4b205
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:34 GMT
+      - Fri, 10 Nov 2023 13:19:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65c18ba0-545b-4773-8cd7-902ed1d0a4d3
+      - ba62faec-06c6-4723-925e-14195aae5c5c
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:39 GMT
+      - Fri, 10 Nov 2023 13:19:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aac2ae7-a2bb-483b-bd62-273a9e3279ac
+      - bcccadd9-e6c1-4487-acaa-0d194d0e154d
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:44 GMT
+      - Fri, 10 Nov 2023 13:19:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff39c7d2-2873-4019-a284-46906b933599
+      - 23825918-59d2-4fbd-bf82-9512c7acc717
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:49 GMT
+      - Fri, 10 Nov 2023 13:19:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f1f9576-67f8-417b-b3a1-603021b0a4af
+      - 93fffdd1-394a-4908-ba05-9d6db83468d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:54 GMT
+      - Fri, 10 Nov 2023 13:19:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f5252fc-fbf7-4382-932e-307037f83bc1
+      - f90dea47-948a-4557-8afe-e48ba48b5018
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:07:59 GMT
+      - Fri, 10 Nov 2023 13:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b56e58c6-bf9a-4737-938e-9be23e43bdff
+      - 4aaff480-776c-470e-b270-b249146fb6a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:04 GMT
+      - Fri, 10 Nov 2023 13:20:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3b201aa-0c9e-44b1-843f-252fc9b2b426
+      - b854d8d8-351e-4d10-881a-60d878a9b947
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:09 GMT
+      - Fri, 10 Nov 2023 13:20:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12721ffa-0ffe-4eb7-8bd2-0b7b86442746
+      - 7f34fc08-e9b9-4e29-9b69-0bbdffed8de3
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:14 GMT
+      - Fri, 10 Nov 2023 13:20:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 442332ab-e637-4c74-92dd-65802f525579
+      - b95efec0-3a53-41f9-ab03-cc7e75433d83
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:20 GMT
+      - Fri, 10 Nov 2023 13:20:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01325b43-3e44-4693-ac3e-45b8fd3cf714
+      - 46a17917-201d-4b9f-a88e-829e9fac9d81
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:25 GMT
+      - Fri, 10 Nov 2023 13:20:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ced4d1c-7749-43fd-a4da-0ddda148ce59
+      - 148ff5bb-e596-4578-9ccc-1bdd13709f6a
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:30 GMT
+      - Fri, 10 Nov 2023 13:20:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c036390-7137-4903-ac27-1f0548070c86
+      - 05aff1ae-33df-48ec-b34b-cf9fc608283b
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:35 GMT
+      - Fri, 10 Nov 2023 13:20:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b34523af-2c02-4e31-abf4-00b3ecced3a4
+      - e0e7216b-9149-4f12-8a98-e852cfbca6a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:40 GMT
+      - Fri, 10 Nov 2023 13:20:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1043c599-9ff2-49db-a86b-5f31ead794f7
+      - e3af8f76-e139-478a-9a19-e51686db5086
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:45 GMT
+      - Fri, 10 Nov 2023 13:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0639b04a-e2ea-4d81-948f-587cccc9ddd7
+      - 91b79f3d-f985-408a-88b6-354917a8a5a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:50 GMT
+      - Fri, 10 Nov 2023 13:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fec78855-2c3f-4f88-b08b-ad24e6553b41
+      - 3df13436-71ef-4059-bc48-b3d7121ef2ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:08:55 GMT
+      - Fri, 10 Nov 2023 13:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 583369e5-b89e-4f17-b370-c11655647b97
+      - 3f5fbd50-ab20-46b2-a2d4-74cb2dd734ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:00 GMT
+      - Fri, 10 Nov 2023 13:21:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4de9c88f-21ed-44d8-825d-6a1d09a548fb
+      - 48ddc086-dd6d-4834-85fa-82420f575f49
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:05 GMT
+      - Fri, 10 Nov 2023 13:21:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af32c4e3-6b48-4ee5-9981-8863d0b69a5b
+      - ba38b196-4e24-4b72-a85f-6b010dbdec80
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:10 GMT
+      - Fri, 10 Nov 2023 13:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ed7b6d8-dddd-4c3b-8f17-d089f393588d
+      - 20a28a0d-bcf7-41b3-b499-d117d4c02859
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:15 GMT
+      - Fri, 10 Nov 2023 13:21:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bcc7e55-8e54-4ce8-8308-78b67a809e2e
+      - 145a55e8-6c7b-405e-a590-bdbd88d62e9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:20 GMT
+      - Fri, 10 Nov 2023 13:21:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7997062-7402-4d07-bc96-6ce3c1f4b084
+      - fe4f7ee2-6e48-4410-950b-f825c4f15820
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:25 GMT
+      - Fri, 10 Nov 2023 13:21:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50225391-7431-4710-b6ff-0b6f6c6247ff
+      - 44c6297c-e479-4161-b43d-fabf2b9e4fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:30 GMT
+      - Fri, 10 Nov 2023 13:21:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc632d8c-76a9-4d83-9420-26501850f689
+      - f7c9d958-1d72-4095-89e0-f01934a212d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:35 GMT
+      - Fri, 10 Nov 2023 13:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62ad9813-5ee6-4c86-8863-36c564a4c5e8
+      - ed9dd236-3dce-46fe-bd9a-b26766b1bb96
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:40 GMT
+      - Fri, 10 Nov 2023 13:21:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4741bfba-6756-4070-8ac8-82b8748ce7e0
+      - 5ad22eeb-909f-4239-a4fa-1fe156c64bb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:46 GMT
+      - Fri, 10 Nov 2023 13:21:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c36f0110-c266-4658-86fa-1dbfa97c128e
+      - 5af3c997-ff10-4d20-bcc9-d407f3627305
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:51 GMT
+      - Fri, 10 Nov 2023 13:21:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b02a8c8b-bf64-4da4-9938-88bf2b27723c
+      - 688230b2-b011-4284-98f7-26e5f7645f42
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:09:56 GMT
+      - Fri, 10 Nov 2023 13:21:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f072905b-ce72-42b5-ba2e-f7d8d7891183
+      - 3da54714-b5fa-4927-bdae-4e31435d25f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:01 GMT
+      - Fri, 10 Nov 2023 13:22:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad6c1e93-09d4-4596-a79e-e5ff08c5c279
+      - 8197ad39-c47d-4ce0-93a0-44d095c4e066
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:06 GMT
+      - Fri, 10 Nov 2023 13:22:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1872be2d-376e-49d0-9a93-254874a43471
+      - 299e7ff5-f86c-4e01-bb8c-e0dea194947f
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:11 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c83f929e-cc44-4835-9800-8ee242680dea
+      - d686bd2a-4020-42ee-b937-e230267d0861
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:16 GMT
+      - Fri, 10 Nov 2023 13:22:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd43fe4a-a0bc-45db-bc8c-b5f876a39045
+      - 5daa6758-6c2e-44b0-8b31-3be144985cf7
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:21 GMT
+      - Fri, 10 Nov 2023 13:22:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 929c8305-25f2-4b80-ab51-6f3f0e301eac
+      - 3ddbcb69-544c-45b4-94e0-7262ded5f98c
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:26 GMT
+      - Fri, 10 Nov 2023 13:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 454776bd-c45e-4fcd-9d63-9ddb6087d4d3
+      - 1a500c4d-d767-4d62-84f0-0b786251b919
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:31 GMT
+      - Fri, 10 Nov 2023 13:22:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58df8d93-e7ef-4091-abb4-bf16040235d4
+      - 09fbfcf9-0344-446a-a2ce-5c393187c235
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:36 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc79e582-6b03-4deb-8a2d-7bc9c61ba234
+      - 97a09eab-2633-4055-b31d-76210009fabf
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "606"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:41 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a638b7fb-538f-4c73-8025-85bdfc774be5
+      - e4485591-5779-4e3f-80ab-c44f228eefc0
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:46 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0733fa4e-091b-4b3b-acd1-ce523827016b
+      - f2a9aad6-82e1-4d29-bcc5-76022cf43f24
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:51 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f87fd29-a1ef-4e29-9327-be91114d0e03
+      - d693352c-a540-4e9e-b257-e2084eee2a23
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "606"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:10:56 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2666aa81-748f-4762-b8c5-c94fd3a86629
+      - 60ffb27f-df04-490a-b8a6-31c7ed00a36a
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "606"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:01 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b57e9abb-22b0-481f-b7c9-798d94d438e4
+      - 688219e4-773a-4cbd-84bb-84b11d60585f
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:06 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5671bb23-7ed8-4aa4-b37d-98577dcbb478
+      - 450cd6b0-338a-4461-9ff7-d8da5c95ff06
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:12 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93af2303-2881-4394-a2ee-795b1463d6d5
+      - b0fcf951-4700-42b8-9c80-455bd30283a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,452 +2493,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 713a2e49-0794-41db-9171-379cb172f84a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d255cd9c-19f7-4fb4-b9dc-db76f9a16105
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 413da506-6774-43bf-8378-0c802ba45e5f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cee15cbe-acd6-4b4f-9d86-598740766dbf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9445b578-7275-48ca-a0db-167989ada726
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3598f41b-c956-4879-bf4e-d45d919c98b8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1455"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8c6f9ff-c380-42e5-96be-e0373441cf32
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9ddd4cb-e284-4702-b1c8-b8b0e44c6b20
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a301c240-321e-4781-8517-4d554d4665b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1455"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 311371ce-c74a-453a-a5ae-b0a2aeaea4ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6afda5f1-9a32-4c5e-ad28-0825ee95f44b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d466e66-0279-4fcf-8a5e-0eee6b88783a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48a7c261-5745-47fb-8337-8e9dec98c04b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/be05aa69-3d5f-45ec-8ea4-cd0d3d455712
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T16:08:28.600272+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-06c629","id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:2a07::1","gateway":"2001:bc8:610:2a07::","netmask":"64"},"location":{"cluster_id":"47","hypervisor_id":"102","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:fb","maintenances":[],"modification_date":"2023-11-07T16:08:45.102071+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.194.65.79","private_nics":[{"creation_date":"2023-11-07T16:08:29.262776+00:00","id":"e2d355bb-c296-4b6d-9d43-cda00caf50e9","mac_address":"02:00:00:14:a4:11","modification_date":"2023-11-07T16:08:30.156714+00:00","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","server_id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"8ee2862c-bbf8-44af-82cf-9ec4d2265dd9","name":"kubernetes
-      39d9f145-02ea-4e4e-a5da-f146630c632b"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=39d9f145-02ea-4e4e-a5da-f146630c632b","pool=308c7294-01ad-4afe-9a9c-1feac3e1a142","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=06c62993-3874-4d90-99f2-3aac9161cce9"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T16:08:28.600272+00:00","export_uri":null,"id":"c97beb96-de3c-4387-bcb0-fec23e8602a5","modification_date":"2023-11-07T16:08:28.600272+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:19:31.379643+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:660:1000::1","gateway":"2001:bc8:660:1000::","netmask":"64"},"location":{"cluster_id":"90","hypervisor_id":"501","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:41","maintenances":[],"modification_date":"2023-11-10T13:19:51.232798+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.252.1","private_nics":[{"creation_date":"2023-11-10T13:19:32.369675+00:00","id":"41a374e9-b564-471a-aef6-d6895a8bee4c","mac_address":"02:00:00:14:b3:b7","modification_date":"2023-11-10T13:19:33.548970+00:00","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","server_id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.156.119","dynamic":true,"family":"inet","gateway":null,"id":"65b0aefe-db56-4c20-a811-61f69dbb375b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.119","dynamic":true,"family":"inet","gateway":null,"id":"65b0aefe-db56-4c20-a811-61f69dbb375b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"08cfdf0c-43d9-4724-aae4-9b83ce62f24f","name":"kubernetes
+      7401da5e-0973-4cb6-848b-ffd3d82b7088"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=7401da5e-0973-4cb6-848b-ffd3d82b7088","pool=cde5d791-3c55-43cc-8e1e-6c72b195deef","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=9a91c1ff-74dc-41eb-8101-da96273fc049"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:19:31.379643+00:00","export_uri":null,"id":"36361446-d28a-4571-9644-764b97088dff","modification_date":"2023-11-10T13:19:31.379643+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3966"
+      - "3969"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:42 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bab0a722-aa22-4b46-b8a9-1ca09b8c0e2d
+      - 7ed9a36a-7b50-46e0-904c-d92be339c0e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,19 +2530,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:43 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 273741cc-63c8-467b-8bf4-24a3b4591ecc
+      - c5edd1f1-9ab5-47e7-988f-f2bb613d2b5b
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:43 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71b1111a-5f08-44d9-a04f-bd5d8b70d364
+      - f60c5a2d-8395-440b-a0f4-96f953f2ce5a
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,19 +2596,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:43 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6114f374-ab41-48e7-b8e8-5c7beacc39a8
+      - 42d3290e-232c-41ae-bc08-c3fff940622b
     status: 200 OK
     code: 200
     duration: ""
@@ -3058,19 +2629,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:43 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3080,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce1fadc0-7d07-4e3b-915a-9bccbc37da66
+      - b965d305-f9f8-4843-a093-68db0b7e6528
     status: 200 OK
     code: 200
     duration: ""
@@ -3091,19 +2662,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:43 GMT
+      - Fri, 10 Nov 2023 13:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3113,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4abcae5-e586-42fb-b3c3-8bbf903dd38f
+      - b95d7998-15d4-4784-b715-f59df7b0395c
     status: 200 OK
     code: 200
     duration: ""
@@ -3124,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:44 GMT
+      - Fri, 10 Nov 2023 13:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b477b57-194a-459e-80d5-c3ecd581af2b
+      - ed3bb9e5-2114-4b2c-8c0d-1a64573fd48e
     status: 200 OK
     code: 200
     duration: ""
@@ -3157,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:44 GMT
+      - Fri, 10 Nov 2023 13:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7abf2383-e84d-4e8d-969e-7ef1f490b5c8
+      - 1fc91f7b-959a-41af-a4eb-5bab088b03bd
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,19 +2761,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:46 GMT
+      - Fri, 10 Nov 2023 13:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3212,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2b7afff-ddb1-4e74-8a48-078489093b19
+      - b003c0af-1e9b-412b-9097-574b52428492
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,19 +2794,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:46 GMT
+      - Fri, 10 Nov 2023 13:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb0534fc-2c50-4c3d-b94a-56f7ccf25b63
+      - 284745e1-eca8-49a2-987e-54bcb09afbc6
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,19 +2827,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:46 GMT
+      - Fri, 10 Nov 2023 13:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c036a62-0f77-41cd-834d-ea5cfc633fbb
+      - b0508aee-e377-4a2a-91ee-eaf3cf884c90
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,19 +2860,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608334Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261201Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "610"
+      - "633"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:47 GMT
+      - Fri, 10 Nov 2023 13:22:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 455dee2c-3178-45f4-815e-2610b8cc6f2d
+      - 4acec69b-1c26-4e49-9ff5-93dd8655e091
     status: 200 OK
     code: 200
     duration: ""
@@ -3322,19 +2893,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:47 GMT
+      - Fri, 10 Nov 2023 13:22:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3344,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc0c4c31-b67a-4d46-973c-fae6350064a4
+      - 1b6355ba-1071-4b3e-a5ad-f69c7818de6d
     status: 200 OK
     code: 200
     duration: ""
@@ -3355,19 +2926,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:52 GMT
+      - Fri, 10 Nov 2023 13:22:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3377,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 026b8aae-cb2a-42ca-8dec-e4cbb257f630
+      - 6be4f56d-77a6-49f3-8a7e-bc16e75244f7
     status: 200 OK
     code: 200
     duration: ""
@@ -3388,19 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:11:57 GMT
+      - Fri, 10 Nov 2023 13:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60516772-523f-4512-89c5-ed5778468c85
+      - f10996f6-991b-4272-ab92-c47098e7d4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,19 +2992,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:12:02 GMT
+      - Fri, 10 Nov 2023 13:22:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3443,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88683df0-807e-492b-8ecf-337356b9533f
+      - cf6fba0f-ace3-4295-9999-7d5a6b5aa854
     status: 200 OK
     code: 200
     duration: ""
@@ -3454,670 +3025,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0cc5af5-06e6-4a79-aafa-fb3458e563df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5e5f7ab-8743-4c1d-bd0f-e8d103d28ad5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a42ad51f-ac6d-4d12-915c-66606b12a052
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea6e24f4-9e48-4602-bd92-b52527d9e145
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af9c3332-f40a-4165-9a30-a9241d9da26f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 342d6262-a3ed-4974-b47d-af0cd25e1832
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9e159cc-9ffd-43de-b0fa-15894f1a474e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9f81aa7e-3e36-4f41-b4be-b07a6d0d9d45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 758ae1b4-b28f-452d-a088-a6e104e6c7b0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5094cbf3-637c-4a0e-b6cb-1ccb6671bba3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:12:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 28ce6e43-4310-4755-981e-83dc128a4a73
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ef89433-d3d4-4af4-bb8e-c828d702901b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - db33fd23-e509-4449-8b8a-4d5374d2a536
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4e402f52-aa68-4234-a63a-52d48b62bd87
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e90fcdef-e4da-4cbc-9827-ba117dcfe51e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cfd4556a-7f3c-41f6-992c-35bdfb2dc264
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1428c60-ade5-46b0-b0f4-1fe4618c9d0b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25492f8a-912d-45e4-ac04-0da37be1fe47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ffab148c-b8b8-43c2-b5ca-9e9dcec84c75
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:13:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 932e750a-9140-49db-a69c-2bd8a9a773ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4126,7 +3037,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:48 GMT
+      - Fri, 10 Nov 2023 13:23:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4136,12 +3047,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e32ca357-3694-4c1f-b9bb-aa4432fe2377
+      - a9349bbf-e6cf-4536-b265-68a0002653a2
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.0.0/22","push_default_route":true}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.0.0/22","push_default_route":true}'
     form: {}
     headers:
       Content-Type:
@@ -4152,16 +3063,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:49 GMT
+      - Fri, 10 Nov 2023 13:23:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4171,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b7f27b7-13d4-4f78-a98c-a42b1d3c3443
+      - bede240c-ae94-4d40-9d94-ce9671509940
     status: 200 OK
     code: 200
     duration: ""
@@ -4182,19 +3093,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
     method: GET
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:49 GMT
+      - Fri, 10 Nov 2023 13:23:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4204,12 +3115,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc45b97a-cdb0-4b6b-89f6-7e83f37bbab2
+      - 788e05b5-a5cd-4cc9-9068-5daaed9db2ce
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-k8s-public-ip","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-k8s-public-ip","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -4220,16 +3131,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:49.690251Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:01.508994Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:49 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4239,7 +3150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 709dc931-5ad1-4368-9884-8c38ecc176b9
+      - aac37600-84e5-4862-835d-c38297f303bb
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,19 +3161,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:49.753152Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:01.551192Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "957"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:49 GMT
+      - Fri, 10 Nov 2023 13:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4272,7 +3183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a462b85e-2fb4-4a73-ad94-f8ed62788622
+      - efcb809a-cfc6-48d7-9a8d-df656e151253
     status: 200 OK
     code: 200
     duration: ""
@@ -4283,19 +3194,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:54 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4305,7 +3216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 765c4aeb-e703-4034-b86a-665e0f9dd99f
+      - 7a19ee2b-632c-4b93-b6c8-36f510065e36
     status: 200 OK
     code: 200
     duration: ""
@@ -4316,19 +3227,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:54 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +3249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 355b0973-863f-47b6-b239-87611d15851a
+      - 2a5be9e2-486d-4a4a-a2ea-df808b6aef0a
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,19 +3260,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:55 GMT
+      - Fri, 10 Nov 2023 13:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,12 +3282,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f27884e0-f075-4e22-b083-6009c5ab623f
+      - 059e6fcc-8ab0-4e56-a8c6-65a478641dfe
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9a11d235-abb0-476b-aefe-580f5054044b"}'
+    body: '{"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"08348404-aed3-4b73-9f45-3c428b1836f2"}'
     form: {}
     headers:
       Content-Type:
@@ -4387,16 +3298,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"created","updated_at":"2023-11-07T16:13:55.899920Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:56 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4406,7 +3317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76700c43-ee3c-486c-8dce-48c4269280f5
+      - 8c004484-e457-432c-a874-5f3954b1c7d4
     status: 200 OK
     code: 200
     duration: ""
@@ -4417,19 +3328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"created","updated_at":"2023-11-07T16:13:55.899920Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:56.085179Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:07.857150Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1910"
+      - "1963"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:13:56 GMT
+      - Fri, 10 Nov 2023 13:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4439,7 +3350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52a8a573-c63b-45ce-9b7f-60dae99b5af9
+      - 28c62b9f-99c2-48c7-959d-74d96e0f7330
     status: 200 OK
     code: 200
     duration: ""
@@ -4450,19 +3361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:07.857150Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1919"
+      - "1963"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4472,7 +3383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dfe645c-e944-4223-90be-d5055f8e3c5e
+      - 9b614ea9-287c-445f-af03-854747f2b8df
     status: 200 OK
     code: 200
     duration: ""
@@ -4483,19 +3394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "1972"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4505,7 +3416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45554bad-bd6d-4cb5-89bd-aab256fce6fb
+      - b4cdcc56-3d99-4b65-9cd0-dfe77585bb64
     status: 200 OK
     code: 200
     duration: ""
@@ -4516,19 +3427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4538,7 +3449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c18d0ff2-a66c-407a-99cb-2184dc2a0e32
+      - 3743cef3-6f32-4206-9455-0958710b68d6
     status: 200 OK
     code: 200
     duration: ""
@@ -4549,19 +3460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1919"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4571,7 +3482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 382e7b44-01bf-462b-8983-e04115259661
+      - 14c51f2e-a1ea-4b30-82d1-fb761da36d3a
     status: 200 OK
     code: 200
     duration: ""
@@ -4582,19 +3493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "1972"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4604,7 +3515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8ec3766-1e6f-4729-9ea5-ae7ce2410462
+      - 02628363-732f-4d6e-b9b4-bc8f9b4ad693
     status: 200 OK
     code: 200
     duration: ""
@@ -4615,19 +3526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:13:47.945248Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1463"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4637,7 +3548,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 764433b8-6f2e-4871-ae7f-d7bf5a75630d
+      - 7c70cb89-7efc-4844-9722-beb4026289b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:22:59.664556Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1508"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 848c3707-f14c-4f91-bee8-1521cae82c51
     status: 200 OK
     code: 200
     duration: ""
@@ -4650,19 +3594,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695285623Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405142865Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "608"
+      - "631"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:14:01 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4672,7 +3616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8797c5-9cd1-4aeb-aa8c-8f0b4854ce05
+      - 4488e081-7029-4809-9f3b-cb49272c102b
     status: 200 OK
     code: 200
     duration: ""
@@ -4683,1858 +3627,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 064d2ce0-e491-46f7-9cec-5d14855a92b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 175feaf0-bc8d-4193-a254-aeabbf8546ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1eff3741-d2d2-4a43-96bc-03aee58a75e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6913305-25f7-4fdc-bb6b-d25006333dcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee9bc802-ec52-4353-af86-db03594512d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d64331b-712a-4bcf-b42d-a11ccfa20219
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25fb2df8-2d92-4b09-8e2c-ec93703d6080
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a43ceaef-37a6-4df6-a2ed-96c48b174109
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e0d7614-0ea0-4442-b12b-3a70f9d26896
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef011e27-7093-440f-af26-d6ecc4d62cd8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d352f80-97d0-4da5-afeb-47198d115008
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:14:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 43aa6c45-1525-42b6-9188-36fcc3159974
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c7df9f74-64d4-4e1c-b21a-e0b04f1d06b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58318f47-3248-4090-9c6b-2f29b29d3d0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 47880554-0f62-43f8-9d6f-8fc0a3957da2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ce208224-b387-471d-b5db-7cf28745e116
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f62ade79-265b-43a0-90c8-d9e216f7f324
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 710d5149-4792-4723-9290-7ffdf703de12
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1282e51e-d9f5-4653-bcc6-641e017baba5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ffd5d852-d47c-42f9-a6a7-fed45b8c11ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f12d7dc8-1ebf-417f-bdcb-4963d86ac9ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f50be189-78f9-47b2-a7b9-0feea196e819
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08c60956-f824-46b3-878a-04a96c3e2be9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:15:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 694fa839-c80f-4331-832a-ad129b1459a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d567da5b-3d09-481c-bd3a-9995f5037558
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 05c0f23b-fcdc-4f94-942a-6a3fc8674a16
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97974cab-abc2-4e02-8d0f-a6654f2dbb72
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af070591-4b74-4af8-8cf6-f84a58141b22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dab8e9e1-42f2-4af5-bb97-b07e4797f0ff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b52f78fe-9b31-4d19-bf52-0b9590dd7a00
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6c28754-7f85-403a-82b2-ae0eeffb3d4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a097c6e6-6c05-432f-b236-35e67fec009e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8804848f-0abe-404a-91b5-6c842117b929
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b74f4834-2938-413d-a8d5-9de8ea10a74f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5b68fa0d-df8e-483b-aa6c-29878d16fda3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:16:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f490686e-c0bb-432c-a46a-3f62a8031c9e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37ad37dd-c281-4c7b-879c-a1eb77bfb4c3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8b8f9a5-e91b-4baf-8f12-1c51ba7f06b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 402bc26d-4d42-472c-be15-96c280e6590a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3807173-088f-4363-928e-8b0f5a918fa6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2f9ea8a-3d93-41de-a119-b5a03f7cb59e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c811b67c-f87f-4e99-8a81-0d93ddfef7d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b1ec5a8-5bbb-4922-8894-3078b516785a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c224bf9b-16a9-4121-a78b-121a644df834
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4a8e6d0-d45f-4c1b-bcc7-62b9462a9451
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35b390c8-8016-48fc-94e4-7b2aac3f5b5e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f3ea37c-ce7f-4403-b3b1-4bb3e13afe43
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:17:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78c837f6-d8f9-43a2-8689-ab13c7e6d8a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c63480b-2520-413c-aece-0ec563bf9f98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab294d31-c3c2-4624-b65a-4105051f5575
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f52bf23-e617-435f-bfda-f2eb1ac804bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3454b135-382f-4ec0-aacf-062a6f687ac3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75dd730d-9d14-4875-b0d4-3a01e762b370
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "603"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3e2a663-36cd-4456-a99a-1a4566b2c657
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1455"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80afccbe-45b7-41bd-8464-7a3e4f031d2f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "603"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3ded353-ec94-4ced-9031-8f65cdba1766
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6543,7 +3639,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6553,7 +3649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bbb0a69-dae3-4d20-9648-ba946ac37b2b
+      - 96975d63-3494-47c1-a0e7-e573e6dc803c
     status: 200 OK
     code: 200
     duration: ""
@@ -6564,109 +3660,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1455"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c9041f5-a13a-446e-9348-4cf80fafe946
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:55.400175Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:13:55.403852Z"}],"tags":[],"updated_at":"2023-11-07T16:13:57.844907Z","vpc_id":"733d8205-e6f3-4481-abc1-d3d8760a8139"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d305caad-42b9-4b76-b5f8-aa7477ba8999
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "603"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 36770158-45d7-4497-a434-ad8ee862e198
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6675,7 +3672,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:30 GMT
+      - Fri, 10 Nov 2023 13:23:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +3682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f33bd29-2ba8-4223-bf7c-5698e41beff0
+      - e3544067-a1e7-4a7e-842e-b34b1e012d59
     status: 200 OK
     code: 200
     duration: ""
@@ -6696,14 +3693,1994 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/038043dc-93d2-40f9-8b0e-690d1f35ebbe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52487d29-49c0-44ec-8095-4ddce9fbcc15
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a69f0d0f-67f6-4445-b304-89497db1dd79
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9afe37a7-16a3-4a26-96b9-9c5a9066127e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61c21fc1-7b99-4772-8498-a0740ddf21c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f5726a5-d0f2-4f25-845e-9dc6a087d690
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66f22b03-93e1-4bb2-b8db-06c7ff6b070e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae8a0eea-19c4-4213-b4bc-6f292a8d83a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1957524e-2542-433e-abb2-5df553a8041c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7cbe535-94d7-4efd-8ebe-f272eee603d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4d1d68bc-6ff7-4bfe-9194-b9a4f20e4514
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a93cf67-aed7-4525-bcfc-9e7e390be259
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20fbc479-1a1c-457d-8552-49f8c042dbf7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b06b7c90-2ff1-4f23-9b9f-1ad34dcf1718
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - daee81d2-6f16-4150-83c3-90a4438da978
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f209b95-7fa9-4fca-a5e8-7aa1a0a389ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab43c5b6-8f57-4ccb-80f8-cc8787aae075
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 981ffede-8ecf-4f80-8995-6b6bd81ad672
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:24:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c27d3d7-d21c-4b9d-b05d-4343b75c7abf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 920b81a0-7169-4b24-a7a1-36a385266e5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3c0fcd9-7866-4426-a129-3717f1e64055
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - abdb0a8c-ed69-4fee-b4a8-92993a3ff9e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34126772-8e33-445a-a1f9-7be97aa0eaa1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95360ce0-60af-4aa0-926a-b82a22fb6613
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7000a316-0b4c-4cb8-83b2-76943681b71a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8041e704-12b9-4e7a-94e4-0e57f0142781
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77b72e25-79a1-418c-93d7-42a62c0a57af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0d130038-b49f-4b58-b61b-26315f2dd0f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0edacd73-0939-49f9-a852-5b1b92199be8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 090d06a8-3c42-44b2-9ac3-39d5a8cdaaf1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3a80a03-8319-4c56-b773-bb6f20ba431f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0537d11-7a85-430b-8611-a14d2167386a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 992de3d6-79c0-40ea-80e1-f105d2e9c149
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e087cab1-cb6e-4e6b-a4d6-d766fb9ac681
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61734d1c-0f7f-4178-8573-c514b88c5c13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b0a122e-daaf-4c18-9ca0-ad4d90f83911
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4aea49fa-5c27-43e4-a386-ac8a8459d918
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd3b1436-85f7-4274-8a9a-917d64021e04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f0f46acb-d2a4-4cc6-a53b-8835210e99e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7751b3ee-850f-42f5-aded-736ec9b22615
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c798d246-514d-469c-83a8-d8da485d6a83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 03b53144-a3fa-4dd6-b18d-26723164ac7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c15b4a81-9864-4db4-a490-13a4d49827ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f3f2c024-2b64-431c-ad8f-5ba37d43ffad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a06d9e4-a68c-41f3-b26e-c9be4f82ab94
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af82a086-5610-4f16-8152-adde7d53bec1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40955248-d410-43fa-9eca-3987b452d722
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd8762a6-de91-4f4e-a448-5932a46b064d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a05ed6b-4944-4a4d-a0ae-049b34951fe1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89f516a4-d48a-4248-b64a-adf640837e1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2e8a1b83-7073-4a83-9926-84afb92c11ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37e252a7-e918-4c32-b7d3-26a8c8ad7172
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99eb4ab4-3cbd-4496-a8b7-aa1133565aac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4eb0d4d3-d034-4f40-93b5-50e8527b8bd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1500"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd13331f-0302-4c00-a9af-9a03b457739d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2894cda5-ebbd-4301-8b99-522012af7176
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42d47a34-3f86-4154-b9db-3a15fa38b15f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1500"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fc76268-354f-4ed4-a549-c7e38112ed9b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:07.135324Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:23:07.137733Z"}],"tags":[],"updated_at":"2023-11-10T13:23:14.602149Z","vpc_id":"8a7826ee-a226-40fc-9878-4e533272333b"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55bdcd42-546e-4571-9728-c6ed99ebb400
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82bbdced-4191-4d7e-8bbc-0684ab7bde31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ed0c8d1-167a-4f5e-b5c9-34becfa1f522
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/297e5d54-9b93-4e61-9723-750675a5cf6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T16:15:35.059441+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"29","hypervisor_id":"602","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5f:4d","maintenances":[],"modification_date":"2023-11-07T16:15:49.662790+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.66.76.193","private_nics":[{"creation_date":"2023-11-07T16:15:35.816671+00:00","id":"9627f7ec-0873-487e-af23-c721cce340b1","mac_address":"02:00:00:14:a4:1f","modification_date":"2023-11-07T16:15:36.663237+00:00","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","server_id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8ee2862c-bbf8-44af-82cf-9ec4d2265dd9","name":"kubernetes
-      39d9f145-02ea-4e4e-a5da-f146630c632b"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=39d9f145-02ea-4e4e-a5da-f146630c632b","pool=1eac1bd9-8533-4d1b-b549-a1ef95831940","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=6009f374-7e80-461a-9638-aa60ee66dba9"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T16:15:35.059441+00:00","export_uri":null,"id":"01f83a60-f844-4d27-a19b-474c6e270be4","modification_date":"2023-11-07T16:15:35.059441+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:25:34.774686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","id":"297e5d54-9b93-4e61-9723-750675a5cf6b","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"51","hypervisor_id":"702","node_id":"3","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:8f","maintenances":[],"modification_date":"2023-11-10T13:25:50.100477+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.82.69","private_nics":[{"creation_date":"2023-11-10T13:25:35.773485+00:00","id":"9bda0dbf-764c-494b-b030-24c96fa080eb","mac_address":"02:00:00:14:b3:c6","modification_date":"2023-11-10T13:25:36.671669+00:00","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","server_id":"297e5d54-9b93-4e61-9723-750675a5cf6b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"08cfdf0c-43d9-4724-aae4-9b83ce62f24f","name":"kubernetes
+      7401da5e-0973-4cb6-848b-ffd3d82b7088"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=7401da5e-0973-4cb6-848b-ffd3d82b7088","pool=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=0b722196-710e-49dd-8c90-6b4bc0d656ca"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:25:34.774686+00:00","export_uri":null,"id":"f0d6725d-cec7-4a0d-b68a-53acb9b80d37","modification_date":"2023-11-10T13:25:34.774686+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"297e5d54-9b93-4e61-9723-750675a5cf6b","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "3480"
@@ -6712,7 +5689,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6722,7 +5699,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6df69012-a86f-444a-90ba-86d9203bc3b4
+      - 352b7b7f-4de4-4a86-bcfa-ea3a3ab15def
     status: 200 OK
     code: 200
     duration: ""
@@ -6733,19 +5710,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:07.135324Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:23:07.137733Z"}],"tags":[],"updated_at":"2023-11-10T13:23:14.602149Z","vpc_id":"8a7826ee-a226-40fc-9878-4e533272333b"}'
     headers:
       Content-Length:
-      - "1919"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6755,7 +5732,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e747c9b-0ed5-4cde-8165-2b1f7e11b480
+      - 2bc8b914-ae1f-462b-aec3-251930ab2000
     status: 200 OK
     code: 200
     duration: ""
@@ -6766,19 +5743,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "1972"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6788,7 +5765,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c099738-a1e9-4287-b658-6e3181dd4190
+      - ba3910a2-f31a-4e8f-965f-0705be08983e
     status: 200 OK
     code: 200
     duration: ""
@@ -6799,19 +5776,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:55.400175Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:13:55.403852Z"}],"tags":[],"updated_at":"2023-11-07T16:13:57.844907Z","vpc_id":"733d8205-e6f3-4481-abc1-d3d8760a8139"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "702"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6821,7 +5798,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4a1cfe0-7f7c-478d-9594-1c74a4deb9fb
+      - 24378792-9ea1-4d3d-ac79-eb28efea1169
     status: 200 OK
     code: 200
     duration: ""
@@ -6832,19 +5809,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6854,7 +5831,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6dc1eb4-1eef-40de-9df4-f14d3ea6b91c
+      - 5a2b30c0-1f5b-48ad-8cb6-3b854e39df54
     status: 200 OK
     code: 200
     duration: ""
@@ -6865,19 +5842,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1919"
+      - "1972"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:31 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6887,7 +5864,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cb317e0-dcd1-487f-a7dc-f61de3163b6a
+      - 563dbec5-40ca-4c09-811f-cf48f76a8473
     status: 200 OK
     code: 200
     duration: ""
@@ -6898,19 +5875,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:32 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6920,7 +5897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbe0159e-297d-47e9-b822-b7f9adfa1972
+      - 83110573-92b4-4f0d-b061-78a26d561de8
     status: 200 OK
     code: 200
     duration: ""
@@ -6931,19 +5908,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:32 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6953,7 +5930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c244d8eb-d63c-4d75-9d3a-a82e4fa460b0
+      - f4f68248-a4ed-4798-a8e5-3a3adf481770
     status: 200 OK
     code: 200
     duration: ""
@@ -6964,19 +5941,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2636"
+      - "2638"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:32 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6986,7 +5963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79857ec9-fea6-489e-9440-da0c04af9d1a
+      - 8a426fba-621b-432b-b8b1-b5c20342cc14
     status: 200 OK
     code: 200
     duration: ""
@@ -6997,19 +5974,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:32 GMT
+      - Fri, 10 Nov 2023 13:27:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7019,7 +5996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30a441ed-6c23-4135-9e09-3a1ec3f24483
+      - b7a2eb2a-2948-468c-8e9c-ceebf2b61c09
     status: 200 OK
     code: 200
     duration: ""
@@ -7030,19 +6007,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:32 GMT
+      - Fri, 10 Nov 2023 13:27:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7052,7 +6029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 945901b3-270a-473b-a9d7-b56f92e58720
+      - 8492f994-9582-4511-8641-7d8651bc3e6a
     status: 200 OK
     code: 200
     duration: ""
@@ -7063,19 +6040,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226096880Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "609"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:33 GMT
+      - Fri, 10 Nov 2023 13:27:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7085,7 +6062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3652e507-33c3-4ad0-bbf1-448f50ad88de
+      - 51913075-52fc-40d1-b63b-61356be1c5b8
     status: 200 OK
     code: 200
     duration: ""
@@ -7096,19 +6073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:33 GMT
+      - Fri, 10 Nov 2023 13:27:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7118,7 +6095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bba62a86-a8f7-4120-a17f-7ca7ec592573
+      - bcb199bc-9272-4105-b62d-ff5a3accfb5f
     status: 200 OK
     code: 200
     duration: ""
@@ -7129,19 +6106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:38 GMT
+      - Fri, 10 Nov 2023 13:28:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7151,7 +6128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33905644-8f31-42b5-9439-3733a34d1e61
+      - 7c3aea9d-c398-48c9-85ac-885883e2255f
     status: 200 OK
     code: 200
     duration: ""
@@ -7162,10 +6139,175 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db9c180e-80ea-4230-ad83-55637b7fe6d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cfaa77b-b7c3-420e-9df6-44e0ad7d6bfd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfc58697-c852-4457-840f-69427a98aeb6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2565b371-ae6e-4e2c-a630-310d62da298e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ffc2705-293a-4664-b115-6c67a3934f54
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -7174,7 +6316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:43 GMT
+      - Fri, 10 Nov 2023 13:28:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7184,7 +6326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d1ee68e-7d76-4711-a23e-d142e5e655c4
+      - 983aa022-2ba3-4d29-8913-33678235d3bc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7195,19 +6337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673774620Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651777855Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1461"
+      - "1506"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:43 GMT
+      - Fri, 10 Nov 2023 13:28:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7217,7 +6359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baedd61f-646b-46ee-af81-ae7cd7c2efb9
+      - b5fd3b26-0c78-40dd-b409-d0ed45513c69
     status: 200 OK
     code: 200
     duration: ""
@@ -7228,19 +6370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673775Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651778Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:43 GMT
+      - Fri, 10 Nov 2023 13:28:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7250,7 +6392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9138c05c-f302-4ebc-878c-3bc09cd2db80
+      - dcb3e6d0-fd6c-49be-b682-ceef53e8aa1c
     status: 200 OK
     code: 200
     duration: ""
@@ -7261,19 +6403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673775Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651778Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:48 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7283,7 +6425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2788e8b-b256-43c8-a78b-3aeecee9de06
+      - a5090017-acc2-4ff2-973a-4b404ff7eb9d
     status: 200 OK
     code: 200
     duration: ""
@@ -7294,10 +6436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7306,7 +6448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:53 GMT
+      - Fri, 10 Nov 2023 13:28:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7316,7 +6458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f5cdd9e-32e3-4ae4-801c-f706d90947ee
+      - 7aa6a066-b8fd-42fc-8599-fd0ab34b5a46
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7327,19 +6469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:53 GMT
+      - Fri, 10 Nov 2023 13:28:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7349,7 +6491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a51d85fa-93ac-427a-a40a-8a8b94e3c565
+      - 81728329-35d4-48e2-9b64-f1f0b009449c
     status: 200 OK
     code: 200
     duration: ""
@@ -7360,7 +6502,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -7370,7 +6512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:54 GMT
+      - Fri, 10 Nov 2023 13:28:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +6522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1685a8c8-e850-4375-b076-886eddb76d78
+      - 95a01fef-1e77-42f8-8295-55bd21faeb85
     status: 204 No Content
     code: 204
     duration: ""
@@ -7391,19 +6533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"detaching","updated_at":"2023-11-07T16:18:54.010015Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"detaching","updated_at":"2023-11-10T13:28:40.951242Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:54 GMT
+      - Fri, 10 Nov 2023 13:28:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +6555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ba01ea4-4de9-4272-8427-093591bc90ac
+      - 204730d2-1d28-4004-8087-47ac1403520f
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,10 +6566,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -7436,7 +6578,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +6588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8eeee45-4437-4cf9-bb89-212a46e8ba50
+      - 918b98f9-cecd-4465-9e57-9cf42bcbb7d1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7457,19 +6599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "976"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7479,7 +6621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d8818a9-a38c-46a4-a9f2-000f551ec32b
+      - 0deefb2f-7b3d-4c72-ab43-a120a5f8d0a2
     status: 200 OK
     code: 200
     duration: ""
@@ -7490,19 +6632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "976"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +6654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cbfd016-4fd0-418d-a4ee-b51618bc8646
+      - d51b6445-a8ff-4784-adbe-07499f0cee63
     status: 200 OK
     code: 200
     duration: ""
@@ -7523,7 +6665,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
     method: DELETE
   response:
     body: ""
@@ -7533,7 +6675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7543,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d83027a6-519e-4288-8064-6f600851a5d0
+      - a845c606-4336-4a59-928a-9a93a218b945
     status: 204 No Content
     code: 204
     duration: ""
@@ -7554,7 +6696,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -7564,7 +6706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7574,7 +6716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d7e8a2a-3db3-41fc-808c-90960711484b
+      - 62aaa626-1cfa-47a3-8ed1-184135e7d51d
     status: 204 No Content
     code: 204
     duration: ""
@@ -7585,74 +6727,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:18:59.242758Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "954"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8770411-1ec2-4818-956e-09ebec86aa81
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:18:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f7472bd-a394-4b8b-af4f-b3e86c185703
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7661,7 +6739,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:04 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7671,7 +6749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2172a1fd-c166-458d-86b5-1b343e9d296c
+      - 340ab44a-c530-4daf-b7d6-83f0e7814100
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7682,19 +6760,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
-    method: GET
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","type":"not_found"}'
+    body: ""
     headers:
-      Content-Length:
-      - "128"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:04 GMT
+      - Fri, 10 Nov 2023 13:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7704,7 +6780,205 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee2a1cf3-0d37-47f9-b772-e3389437bc54
+      - 04b4de15-6e7f-478d-9102-d9ddcfb8a191
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0fa34a0f-9206-40bd-bb9c-86d53952035b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae97cb85-974e-4afa-a217-d194b29891da
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"08348404-aed3-4b73-9f45-3c428b1836f2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6785ffe-21c9-4650-b414-c3ee8a2b9ab3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2cc2d951-20bd-4c01-a03a-44f77c9b7fbd
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb59d151-1e20-4c35-8d4a-5a33965ae272
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e45ed8a-a451-4604-8f65-0e94912ffec5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bc8dd12-7443-4411-96c6-8a0a0df9a308
+      - aec85d74-aa65-4b49-a1dc-43ba0be89695
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-size","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-size","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45da668c-44c8-4e13-ac35-c63eef31ec97
+      - b083d2e9-e472-4316-9eaa-3ed693f3b9e1
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd074a81-5200-419c-8fe3-a459ba1bbe76
+      - fd08a2ea-9f20-4f68-ba50-79ee7faa677c
     status: 200 OK
     code: 200
     duration: ""
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e04098f-6a41-4478-aa54-6cd962b89db9
+      - afc8971a-5e2a-4888-b79f-686010eed7c5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18"}'
     form: {}
     headers:
       Content-Type:
@@ -155,16 +155,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909371Z","created_at":"2023-11-07T15:49:53.395909371Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:53.427022137Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138060Z","created_at":"2023-11-10T13:22:57.814138060Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:57.826254485Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1415"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ed59bfd-e93a-4799-ad1a-7e82e49e0dd2
+      - c41ee47b-f03d-4fd7-be4c-fe2aab7a1c32
     status: 200 OK
     code: 200
     duration: ""
@@ -185,19 +185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:53.427022Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:57.826254Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1406"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:22:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e64545ec-9efd-4cfe-a7e9-1e00895a6f49
+      - 0f9ef933-edd0-44c4-a202-22273fedbbee
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a070f35-655e-4c7c-b989-b5bc0e866c30
+      - 5e7f1eb4-85ce-469d-9bab-1a385cc0981a
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96099275-c73a-4122-95e5-5a46f9d177b2
+      - aef15ec7-1aae-46b3-8458-caad0c6fe1b2
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ea2ecdc-cd76-44a7-b258-42a9d7ef6083
+      - 895c8277-b6c1-4516-992a-67f98c0f2e49
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab4df752-3a8e-43dc-99b1-6c0176f74d40
+      - 29906876-0e10-4c27-a424-04743793bc3a
     status: 200 OK
     code: 200
     duration: ""
@@ -352,19 +352,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853381998Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468106Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "595"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -374,7 +374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d413054-a86c-4b35-bc88-759c9bff73c1
+      - 3ae31d64-3178-463c-aff5-ec3474961266
     status: 200 OK
     code: 200
     duration: ""
@@ -385,19 +385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:59 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e11fd724-11e2-49c7-a564-62f5b00441d9
+      - 12020088-f25f-444b-becd-720e36137262
     status: 200 OK
     code: 200
     duration: ""
@@ -418,19 +418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e164cb10-6f17-48ba-b3c0-5c38079b5ec1
+      - 5a33626b-4e6f-4fac-98c2-15845d00d8d9
     status: 200 OK
     code: 200
     duration: ""
@@ -451,19 +451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b98aa8-b830-41d4-8e20-15c457f5ed81
+      - fc2c71c4-eac3-48e6-9f5a-e7221a3cb622
     status: 200 OK
     code: 200
     duration: ""
@@ -484,19 +484,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2b204fd-e0c8-48f7-8e2a-fe2ddd5f8d26
+      - 89f17f19-7978-400a-84ca-eba04bc77c9d
     status: 200 OK
     code: 200
     duration: ""
@@ -517,19 +517,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:23:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdbf55d3-b732-4d61-86be-2006ae1e8c4c
+      - 1961c5b7-a878-44bd-89e8-4abd880333e4
     status: 200 OK
     code: 200
     duration: ""
@@ -550,19 +550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:23:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 956c8433-2944-4728-8ec9-dde24ac4bf88
+      - 6f883640-e65e-487c-8e65-27422297cbe3
     status: 200 OK
     code: 200
     duration: ""
@@ -583,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:23:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 349937b7-7701-4659-8ff0-f9c160826888
+      - 27180872-a5cc-49bf-9ca4-14a5b596b32a
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:35 GMT
+      - Fri, 10 Nov 2023 13:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b20c13b-fd1c-4436-85e2-0975e9abc074
+      - 2e81eb9f-db2c-4300-9d4c-3a189ad699e8
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:40 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fefbfcd9-fb5f-48f3-9ba4-156088c6d845
+      - c40b4be8-f316-41bb-9fb6-636302322d38
     status: 200 OK
     code: 200
     duration: ""
@@ -682,19 +682,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:23:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c1eb094-cf37-4e1d-8967-e5c366ba8b8f
+      - e3997e82-98e6-4eef-9e32-500dc554b18c
     status: 200 OK
     code: 200
     duration: ""
@@ -715,19 +715,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ddcd36c-759b-4242-8462-3649040187ab
+      - 346dae92-989d-4e0a-b3e9-14883ca1e9a9
     status: 200 OK
     code: 200
     duration: ""
@@ -748,19 +748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:23:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c43445e1-2fcb-43a8-bf45-0388cf1c36c9
+      - beb63a14-3b7f-41fd-ab9f-72d1176030ad
     status: 200 OK
     code: 200
     duration: ""
@@ -781,19 +781,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4476ddb2-af9a-46ac-bc51-a8f6057c23ce
+      - d5fe00b0-df93-4582-97ce-68c65f1a5fc2
     status: 200 OK
     code: 200
     duration: ""
@@ -814,19 +814,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 770e29cf-8b38-45db-a78d-413f7e842516
+      - 494a68ad-014b-4a01-b156-390e357c7ac7
     status: 200 OK
     code: 200
     duration: ""
@@ -847,19 +847,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:24:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3f3d4d1-e153-48d3-bb17-e40d0434f141
+      - 23ee9bb4-512a-4146-8d31-9f6b143cd409
     status: 200 OK
     code: 200
     duration: ""
@@ -880,19 +880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:24:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71985818-6ed0-4f4f-8fb2-b489393d3579
+      - c09690c7-bafc-4fee-933c-fe6c239c295e
     status: 200 OK
     code: 200
     duration: ""
@@ -913,19 +913,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:24:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa7b3751-f092-404f-a672-ddbe81ad64d2
+      - 4088f29a-dd18-4320-8f20-e0bf254ea50a
     status: 200 OK
     code: 200
     duration: ""
@@ -946,19 +946,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:24:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c5ad233-1524-4db8-95fd-547dd4eceff7
+      - 2e35ff14-f8b1-4c95-860f-0000e505c0d9
     status: 200 OK
     code: 200
     duration: ""
@@ -979,19 +979,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:24:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a288e58-7824-4fe3-882d-00a79147d1f9
+      - ce501c9e-f696-4dba-a218-ec8cb3526348
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,19 +1012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:24:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaa00be4-82f9-4b12-b1d2-10c6e12f3aa8
+      - 0edb59b2-0112-4749-a2dd-93e32dd37a01
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,19 +1045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e48519a-d5ca-4608-86d4-2e22d44e2981
+      - 6fb84550-caaf-4127-bdfd-327fda855685
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,19 +1078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:24:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2640eeb-aaf2-4994-8f24-2e03e07d4f8b
+      - 70330de7-733c-4d43-a23f-542a0200fa8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,19 +1111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:24:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 724ac307-9363-4db0-9f40-70a55a3520b7
+      - f8dd9713-9f35-4c1b-9ff3-0d845f7cf011
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,19 +1144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:25:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff2629b2-fd31-4bae-a0af-75e118bb79b5
+      - 995c1b2d-fb6e-411f-8ce9-175f2fe57a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,19 +1177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:25:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1eff721-2b6e-4a7e-89c9-7e782fcee37f
+      - 380cd98a-a3d4-44db-9041-c9f6f737d12e
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,19 +1210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:06 GMT
+      - Fri, 10 Nov 2023 13:25:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c872128-0d1c-4654-9754-91593e44488b
+      - b884533c-fcbb-4a11-a901-9dd4d227a75f
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,19 +1243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:25:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ac1dff-ba03-4259-92d5-35cd5d1059a0
+      - a47d3386-51aa-44a6-8d26-49ff83ced82f
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,19 +1276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:25:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c456e972-34b6-4578-9586-7e42c70d5cad
+      - e81c470b-fb35-4ec2-9815-cae94e7d4998
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,19 +1309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:25:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23f78939-ea9d-4b89-a6d5-93752fae2fd8
+      - bfa6ec79-fc23-4156-8277-ff19ee50cd88
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,19 +1342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:25:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b237fa0-1ba8-4e82-bd17-bdd30fe629ee
+      - 73f6c5eb-5fbd-44ce-b6d8-16e8ceb7ac8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,19 +1375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:25:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4828f77d-a9eb-4a17-b399-1247de5162dd
+      - a3536b32-ae8b-492b-a4da-3e441d7df011
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,19 +1408,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:25:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c663eeff-27a2-491f-abe9-dcf020937ab0
+      - f7e8fc3f-023d-4593-872b-794dc6e4f081
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,19 +1441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:25:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c39b6710-24b9-42e5-b877-0b5b09e39798
+      - ea9e9e51-1e60-4772-8867-843270ef7851
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,19 +1474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:25:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8ecda96-049a-4d23-b9d1-738d71dd4606
+      - 503cf21e-9b26-417b-bdba-abdd63a96c11
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,19 +1507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:25:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f5209d0-ecab-47f3-95e9-6aadda56461e
+      - 596400f4-d37f-4ea1-96e1-a19688f7ef4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,19 +1540,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f511392b-cb00-47db-955f-f3d1d3e72e82
+      - 25bb3c47-b42e-4a52-bad4-d9fba1c65002
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,19 +1573,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:26:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d11e932f-03cc-4543-a854-b30596252332
+      - 9326bf1d-10a3-48d0-ac34-19824f5aaee1
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,19 +1606,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:26:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf4b4518-8a9c-4c63-aa76-f59d8d78b36a
+      - 59f0bd3b-4c7e-4240-a00f-f79c2f3ed442
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,19 +1639,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:26:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7e76f8c-4ed7-40a8-bfbe-586335f7fa1a
+      - 1d01a300-ef5f-453e-89ba-ef38a3834843
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,19 +1672,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:26:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87f16a69-d634-4aa2-bdee-79118eff1e2c
+      - 469d2105-df0d-41f5-b34b-b2a78a8f897b
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,19 +1705,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:26:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5afaec73-9b6d-438d-a9fa-b94be8f235e9
+      - 5066ac00-e33f-4f1e-98a1-f98a7f772649
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,19 +1738,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:26:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16eab2a6-48b2-485e-9f20-1c6283be56e7
+      - 34f111e9-a10c-4634-bf73-01db44dbde4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1771,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a972c8c-5ce9-4835-a98d-12c4ecf4d32e
+      - 85680634-605b-4334-9ae1-b3d262a829d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,19 +1804,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:26:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0a89199-924c-4daa-a38e-bcfc37679e74
+      - 1afc1bfc-a913-47e5-a149-ed69281a877c
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,19 +1837,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4cf65f2-2973-49f5-98d4-3af76f9fce55
+      - 48d1e422-8437-4dc0-8b07-cbea631ff521
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,19 +1870,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:26:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a11445cd-9bb3-4c10-b066-7a915484feb1
+      - 596f5127-dd31-45a6-a164-f17c5cb039aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,19 +1903,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:26:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f5b367a-edc8-4123-8d2f-32b7e1591b12
+      - 5816d6b8-a9a2-426a-a208-13025b7bb5ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,19 +1936,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f99880b-2208-4702-86a0-6eb82c991bd0
+      - 098f9353-faf4-4c7b-aa4f-5e04c36ef440
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,19 +1969,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:27:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d99a81a-3a3f-44ee-b1f7-e9764203a241
+      - d2a6eb97-dbe1-4760-a3f8-7fe9b6f6e0f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,19 +2002,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:27:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1e8ae9a-8119-41a4-a7f4-706079da6bbe
+      - f10d2641-4d6d-4750-8fba-332e5287798b
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:27:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edfdd9f2-9dbb-4818-82ea-98cf448da4f2
+      - 48b4ce6e-be07-47f8-b7b3-003a059c3432
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:27:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b0dbdad-86be-44ab-8aa5-1a508a48c3f2
+      - f37bc8dc-2c7c-451d-a933-0169514437be
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:27:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6191e568-bfe5-46fd-92c8-904f859ddbd0
+      - 86c58292-f28e-4ef2-8a67-990ab99eff10
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:27:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc959185-0240-430b-a005-e4522955f248
+      - 94d79c09-6a22-45cc-ba25-df4f7bd3331e
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:33 GMT
+      - Fri, 10 Nov 2023 13:27:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17579a1a-6c98-47e9-88c0-559e28130518
+      - c7e9fd0d-63d9-4050-af75-a40ee61db7bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:38 GMT
+      - Fri, 10 Nov 2023 13:27:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f510feb7-6432-44f8-915a-3bda4041629e
+      - 41b28b71-5e37-4ae5-8abb-f1a9640cf7c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:43 GMT
+      - Fri, 10 Nov 2023 13:27:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d0a0f3e-8397-4b7e-8a0f-8bd23d9f799c
+      - a1d1fe60-fafa-4e09-900f-e38d03575fb2
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:27:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b71b560-4080-47a3-9173-d35c19b17f6b
+      - 5db85b84-0922-4214-9bff-81dcd59de3aa
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:27:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a30c73d-d0f1-46e2-81ab-fd7b7aabccce
+      - 39e2322d-a395-4ee0-8765-694a5446b6f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39e9ccb6-8d90-4f6b-b753-bcef52b2ee63
+      - 7199eba6-efe8-4919-8bfd-6c940624867c
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "592"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:03 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d452fd9-41c8-48c9-9f5a-fc66836ddf48
+      - 95e32dca-c7e1-42b9-9a26-665b617fbddb
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "592"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:08 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 064c107d-05ca-45b6-86a6-4bba3a8b23e6
+      - 6ccdf688-9927-4829-ace2-c9d649f2e87e
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "592"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:13 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4efd39c0-d419-48bf-8fda-0b9d58d1904a
+      - d0feae9c-22d7-4a2c-b3b1-e20da5a237d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "592"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:18 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86bb51a8-5499-4661-a943-3bdd1bd687fc
+      - c7fc6e3d-a2e6-4fc1-a453-2a89ab09d953
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,19 +2497,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "590"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:23 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f031c964-91cb-46d7-9ce9-6cdb9c60979f
+      - f1df84bc-69a3-40ab-9932-3bdb5469bd0c
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,19 +2530,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1403"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dbb34b8-4449-4bab-97d8-063a9ce47827
+      - 66328794-570c-41a1-838b-3ec10916e811
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "590"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc22b046-7347-41b0-b885-4376e9851a29
+      - 61b8f39a-e6ed-4d08-8f1f-e64d44c55a98
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,19 +2596,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "640"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f76814a9-cff9-42e1-94b8-57eeec4c3031
+      - 8651fcc8-5070-4fe9-9ee8-671a80e9902c
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,19 +2629,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 400d57d9-8f4f-43e8-b79b-79a4389e717e
+      - 1cdbb686-02e8-47fb-b512-1d0020820d27
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,19 +2662,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1403"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7beb66a-18ae-4ccb-a380-d2fdea9a88e3
+      - 94f375f8-1996-4d1f-b153-26b515657516
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 336fe596-c7a2-4c12-866c-08c2a84956dd
+      - 3cd03bfa-b296-4461-a6f9-b4e8ff55e8bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "590"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcf94416-2bb6-4a81-b9b7-63701cb55824
+      - aad16ca1-f9f2-44e2-819d-94f58704a98c
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,19 +2761,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "640"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:24 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39daa3fa-b692-4fdc-92a9-b9c2becf5ff9
+      - 7894594f-829a-4057-85cf-0830d9106ef7
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,19 +2794,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:25 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a35990d-05a8-4ad7-a82f-d5bcb3461368
+      - 70e66139-35ae-483c-b4fe-313a488a447c
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,19 +2827,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1403"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:25 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2849,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e468d9c9-84d4-44b0-ba4c-092c8fb3c6a5
+      - 576f22b0-800d-4ef7-b346-d30c7d8aea49
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,19 +2860,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:25 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2882,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50470fe4-c323-4ad9-af16-ef1969cde583
+      - 3b04ade2-4997-4c4b-b145-8e7d700ea526
     status: 200 OK
     code: 200
     duration: ""
@@ -2893,19 +2893,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "590"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:25 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4c9e575-e361-4dd6-8b59-f14c3eb0c128
+      - dcfa560b-64b5-476a-ae4a-ce8776ec7f1b
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,19 +2926,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "640"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:25 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f693bb94-255d-48e4-ac3c-31bc0adfd857
+      - 9245992a-ea66-4dab-9103-21c3d2631b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,184 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "698"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 483b10af-bd9b-437e-be11-7956bfb443da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1403"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a2e1a7d-ce1d-4967-847a-726dcaaa119d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 69ac39e9-c59d-46d4-a686-fbee4728c2db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "590"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f75af08-bf00-4856-84ab-095dae4a0449
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "640"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1687cf05-353b-46c9-a484-3bd4a9d34c47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073209Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306804825Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "596"
+      - "619"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
+      - Fri, 10 Nov 2023 13:28:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bb19f1d-d062-41ae-b473-743ac61033a2
+      - bf21d2be-3634-4737-90da-5eeb6880289c
     status: 200 OK
     code: 200
     duration: ""
@@ -3157,19 +2992,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:29 GMT
+      - Fri, 10 Nov 2023 13:28:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0a54fe1-fdec-4f3b-8c03-85d23e0bda19
+      - a7c4f46d-2f5c-48ed-8c40-6ffca93b084c
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,19 +3025,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:34 GMT
+      - Fri, 10 Nov 2023 13:28:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3212,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01bfa0a4-5bbe-4185-9cc8-d49a8e0d4373
+      - 93268860-a4c5-4c17-afd5-ec297a80ea17
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,19 +3058,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:40 GMT
+      - Fri, 10 Nov 2023 13:28:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef69448d-0877-4885-830c-c7b3b4a03872
+      - 7191789c-19df-41d3-b53f-1071803d0999
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,19 +3091,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "593"
+      - "616"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:45 GMT
+      - Fri, 10 Nov 2023 13:28:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a798a53a-fb1d-4d09-a051-c629d4381e51
+      - 0bccec5a-d2b9-43eb-aaf5-aeaa9fb18685
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,43 +3124,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "593"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 15:55:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a64773c8-7c04-4e63-b689-b0221a7fabd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3334,7 +3136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:55 GMT
+      - Fri, 10 Nov 2023 13:28:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3344,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0a66511-621e-4353-85e9-1d8bb6f2caa6
+      - 0a756e88-3a16-49f0-8c42-41f9993fdc98
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3355,19 +3157,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258639615Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596922515Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:55 GMT
+      - Fri, 10 Nov 2023 13:28:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3377,7 +3179,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7481450c-a35b-4c0e-85d4-37566a54084a
+      - 49205ce0-4a51-4a88-b9e3-5c3deb75f5f9
     status: 200 OK
     code: 200
     duration: ""
@@ -3388,19 +3190,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258640Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596923Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1406"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:55 GMT
+      - Fri, 10 Nov 2023 13:28:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fdfc93b-18b1-4eb5-ad74-c5606ca6b4f1
+      - 89fe456e-2ef6-49c0-93cc-4e77a8673523
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,19 +3223,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258640Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596923Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1406"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:00 GMT
+      - Fri, 10 Nov 2023 13:28:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3443,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16d26f0f-65b1-4e25-a236-635886d974d3
+      - a4e40864-1835-4a09-9964-209b5088b49c
     status: 200 OK
     code: 200
     duration: ""
@@ -3454,10 +3256,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3466,7 +3268,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:05 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3476,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16f81f9d-7c5a-49de-9440-f4f38910af16
+      - 05523c08-bd48-49dc-b274-ef3c51dcd34e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3487,10 +3289,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3499,7 +3301,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:05 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3509,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a12a10b-4371-4bcc-8855-d44918d07057
+      - 693411d9-a670-475d-99f8-baafb0f34714
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3520,19 +3322,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:05 GMT
+      - Fri, 10 Nov 2023 13:28:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3542,7 +3344,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48eec477-805c-41bb-bc47-8afc3811c25c
+      - ba0a2709-bc81-4fac-b058-710ecff2c50b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c4edc1e-9e0b-4404-a2c9-1cf3298d097f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8435b040-0fc5-4389-a2a1-f7f1cb8bf170
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d9e1f61-6435-4495-a54d-39bd896581de
+      - cbdf1d02-71c2-47b9-a586-60a0febda82d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-upgrade-policy","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-upgrade-policy","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "708"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be840193-c77f-4519-a8c2-36705bca5d17
+      - 6db34709-1b13-4318-9675-edb6187bc512
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "708"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42ee26d1-5986-4907-89a9-49113b69cab9
+      - b51bc51b-4af5-48b3-8a32-1b533faab785
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097024964Z","created_at":"2023-11-07T15:49:53.097024964Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.106145379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035431Z","created_at":"2023-11-10T13:23:29.665035431Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:29.676686733Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14f96dc1-eddb-4c2f-a029-0515aedcd89c
+      - 53de69a8-6e92-4ddd-9941-a710e118d35b
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.106145Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:29.676687Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1469"
+      - "1514"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b6f9401-b8c0-45e0-91c7-e26be774c93c
+      - e7c72781-4dd5-48ab-8a42-84939592fbba
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 747df2ac-59a1-4b19-8b00-55377ec3ad11
+      - 14d74732-5b4e-4da3-89f8-30a7b65733f4
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be5ac9e9-c86f-43fb-b8bf-c66669fba1f2
+      - 1a86ab2c-eda9-4c10-af27-3228a908b68c
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2684"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5fb4720-3fa4-4e7a-ba24-ea7f07e27330
+      - 43640997-ec4f-4910-b310-b1d1bae62e07
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 341e2818-e6a3-4a39-acc0-e2a08adf92ad
+      - 04fc41ce-349b-49af-b95d-ca74eb1569c6
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423194Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613211Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "670"
+      - "695"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d33b306-4992-4df8-93dd-78edb332a484
+      - a91e829c-efc6-4ed6-8caf-6ba034da31a8
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:23:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34b11399-141d-40d4-b0c8-67dc8832f1ab
+      - e7770d92-10ec-497c-a2cd-78ca0ccfab38
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:04 GMT
+      - Fri, 10 Nov 2023 13:23:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af28f39e-ee17-45a1-9bf3-9cc40f0e7dc2
+      - cb6bbdab-8c54-4319-8b3b-0bc91bc762a4
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8d5bbcc-6b4b-4c16-8ca2-4d0c03e15904
+      - 5bbe3833-2e90-4c49-8f74-3a12497abce2
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:15 GMT
+      - Fri, 10 Nov 2023 13:23:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9aac5ff-77b2-446c-a0bc-47de230e39df
+      - 7fb479b3-d2e4-484c-9e5e-44718ecd9fbe
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:20 GMT
+      - Fri, 10 Nov 2023 13:23:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa490675-a79d-42ec-afc1-ac2f91a701e5
+      - f55330b6-3894-4796-920e-5aeacd7d8779
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 093fef7d-8413-461b-9e00-2b8cba3a2bc8
+      - 7b9fe8b2-2a21-4187-bfea-e673e335a5b7
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ee8718f-101b-4b94-8b90-9008daabda5f
+      - 34fdbc9c-ef91-46ca-8fd1-3a3dd1779808
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:35 GMT
+      - Fri, 10 Nov 2023 13:24:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95565b7-1e85-49e3-81c7-b423fcb3d8bd
+      - 3cb57403-7cc0-4347-a967-3af861b588b0
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:41 GMT
+      - Fri, 10 Nov 2023 13:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f445eb58-919c-4425-8166-5988c7610d21
+      - 1e68d6b7-a7d3-4129-93eb-a0a2d1e2d5ca
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:46 GMT
+      - Fri, 10 Nov 2023 13:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 944bb2cb-16ba-4fb7-8bd3-65c53752fe76
+      - 46464c65-c819-4dc5-97f8-1d9dcb72e1ca
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:51 GMT
+      - Fri, 10 Nov 2023 13:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79d7138-1254-4c4f-a6c6-b9543012229e
+      - d7600d3c-49c6-4d75-8153-f44d97cd3b55
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:56 GMT
+      - Fri, 10 Nov 2023 13:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9dd9926-1aba-44ac-bfa9-a110f0cf1d03
+      - 64e6db03-cea2-4398-9634-a6e2f46608ee
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:01 GMT
+      - Fri, 10 Nov 2023 13:24:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ab940cd-10b1-4b03-9f79-2c4632f32cea
+      - b02e1245-888e-4f9f-ab89-18328f44ffe1
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:06 GMT
+      - Fri, 10 Nov 2023 13:24:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e66f4a0-a960-48e9-b1cf-60186da2664c
+      - d8749383-4bbb-4aa5-aa51-01663d0f3306
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:11 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afeb5c08-2fa1-4301-8e5f-0997368ff5b6
+      - 2b2d7fd2-4010-44fa-a606-3b1a7304b60a
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:16 GMT
+      - Fri, 10 Nov 2023 13:24:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a847d1ea-79d6-4542-8fd2-a23b29bf344b
+      - 90880842-6525-4663-93ba-3872d3270eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:21 GMT
+      - Fri, 10 Nov 2023 13:24:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 331d6cb8-acbe-4101-8fca-e5d83c99a1f8
+      - 64401b3f-e98c-44c6-b672-87495192a13f
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:26 GMT
+      - Fri, 10 Nov 2023 13:25:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acd98847-3027-4343-934a-888300aac868
+      - a366dea6-88d4-4586-8ccd-fc4361de2fb2
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:31 GMT
+      - Fri, 10 Nov 2023 13:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62367712-6d6a-4be5-8598-b3e9fd3f1f2f
+      - 128c8760-a3bd-4daf-bafa-f5bb5b64c5cc
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:25:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1ba090f-c30a-45d5-a5b5-b747b4c79f7f
+      - 7b8257c8-7d17-4034-8f41-24f5e5cdbd67
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:25:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dbc15f0-86b4-4c6c-a464-09db35e17ced
+      - 5b80303a-4ddd-49a8-a0a0-9149ebe719a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:25:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ff855fa-2bc3-406d-aaa5-05b52688d946
+      - 0260acd9-d64c-470f-a5cb-ae0f61bda6f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab501d86-0a5e-4757-8ba7-3616f58d2a8d
+      - cc692b9a-dfa1-4f69-ba13-4eaf0ef6507a
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:25:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e553530-0aff-4919-a072-c576d64534d1
+      - 86d02725-4539-4987-be52-b212099c474f
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:25:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ef788c6-c124-4674-884b-8fcdacc7108c
+      - 14537edd-ca7f-455f-8d84-c61e5ca34b0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:07 GMT
+      - Fri, 10 Nov 2023 13:25:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e39296b0-4f9c-4ceb-9c26-1c1b3f73158d
+      - 87a05e83-8cf9-4596-a866-ddaffff55ccc
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:12 GMT
+      - Fri, 10 Nov 2023 13:25:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8a97c77-9ba7-438b-9e02-632ffc0e8dc3
+      - 21f77785-313e-49cc-97e3-1839d15c2053
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:17 GMT
+      - Fri, 10 Nov 2023 13:25:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d118130-195e-4b38-b8fb-00eae0bee059
+      - 8a04872b-a262-4b6a-8cf8-d312de1c4577
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:22 GMT
+      - Fri, 10 Nov 2023 13:25:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74c41ce4-5a63-4e63-9830-3b3570c3d929
+      - 05b1ceee-e8ec-4cdb-8ca8-2599961d86fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:27 GMT
+      - Fri, 10 Nov 2023 13:26:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56079bd5-3eea-4fcf-a233-323279905646
+      - 94877dd3-7f0b-4c67-bd18-f275d1ab5245
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:32 GMT
+      - Fri, 10 Nov 2023 13:26:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f57dc8-83b7-4324-ab0e-418acc21bd01
+      - ab9c1be8-53c6-40e7-b697-c3b217ce028b
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:37 GMT
+      - Fri, 10 Nov 2023 13:26:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e28f425-0b65-44f5-9b68-71ff3a3c54f7
+      - 46911545-f749-439c-b90f-2d8d1af2806e
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:42 GMT
+      - Fri, 10 Nov 2023 13:26:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 858b48fb-bb5d-4bc3-bf4e-bafb57ac8c26
+      - e5437735-30d9-45d5-ae96-79543c248b9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:47 GMT
+      - Fri, 10 Nov 2023 13:26:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6882b51-d341-4096-b6a4-49764813cec5
+      - 45b48a6d-20ef-487b-8261-f61e51f62d73
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:52 GMT
+      - Fri, 10 Nov 2023 13:26:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 235b12da-68d5-4dc5-97de-eb368887d1a7
+      - 11911818-2429-4c9c-af14-3259afe62415
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:57 GMT
+      - Fri, 10 Nov 2023 13:26:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae45fe1-ada2-4834-bb22-0cca6f21a64c
+      - 64155f17-1a0e-4999-bd0e-09cd3b55580d
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:02 GMT
+      - Fri, 10 Nov 2023 13:26:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6585034c-70f5-4d29-86f1-0538267bdd67
+      - 7d72fcab-0e90-411a-ba02-43e92278e1f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:26:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32202bae-8613-4718-8560-e2a6a9df4a19
+      - 0be9a381-c8d6-4f94-bf15-2fcf2c580d42
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab6e586e-298b-4d7e-b5ff-67c0d01de29b
+      - cd55a183-6c4c-4e99-830f-5373ea5dafb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:26:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4f0d2d0-f107-46ec-997c-9aefdf00ff1a
+      - 9b76705d-7312-4bc2-9720-0eed9283078b
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:26:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 530fb147-953f-4d78-8106-85febc9bc841
+      - 0be6e5c3-2741-461c-9fb9-a607910ff1fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:27:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a556949a-89a6-43a0-8a96-38ce55cb2605
+      - 1d371fc2-d474-45a2-9ea4-5c55824489a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:27:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 453b3404-48b3-4872-b154-866aec278254
+      - 39481d1c-2d3c-4e2c-817c-6d92e9b00ea3
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:27:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13a7bc91-a685-44c6-9fbf-e1191d24a1f1
+      - f3e4a093-0fc1-428d-8663-93d31c672271
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:27:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c51c36c-bd90-4b06-b208-b4674ef6ba2e
+      - e813c845-fd0c-460c-bc5c-6374b25b88f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:48 GMT
+      - Fri, 10 Nov 2023 13:27:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 692d0336-b3fb-46f7-9df4-20c11a7b2e82
+      - 7ae129c3-b2e4-477a-8542-9604ef0fcfee
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:53 GMT
+      - Fri, 10 Nov 2023 13:27:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c712f058-716b-45e9-ad88-669d33cd7300
+      - 768cd2d7-d257-45d5-9190-445176f111f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:58 GMT
+      - Fri, 10 Nov 2023 13:27:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2312c493-3f4c-4d91-923a-392bed5efce6
+      - 318ffda4-ead3-4c44-a287-6db0303a95eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:03 GMT
+      - Fri, 10 Nov 2023 13:27:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ead22a7-1f85-411d-9d1a-19b1eb5f0bd8
+      - 846e28ef-2e42-4206-a43e-4fd3375a126b
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:27:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bee5dfbe-5df0-4f30-a27d-2d6f4b76ea6b
+      - f5518d44-2d89-42f6-9f62-8fe40e8df873
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:13 GMT
+      - Fri, 10 Nov 2023 13:27:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d2d1949-f812-4fc1-a041-15052ff5d75f
+      - ccfc44a0-e1db-4d56-9f24-2a9385018c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "667"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:18 GMT
+      - Fri, 10 Nov 2023 13:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0a87b75-dfd3-4f10-940f-2416a15c1f5a
+      - a4307c00-d280-4393-9eb4-372051006008
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:27:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea90610b-02b1-43d2-a917-64d4eefd85c1
+      - a98e4857-63e2-4156-9f46-e61ef1418c35
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1466"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baea5ea4-b6d7-4f30-9947-368a0e75e132
+      - 36cd2532-23f8-4523-88b6-22214affc2fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6232db2b-eac1-42bd-a79e-3fcc55435a90
+      - 4902ae2c-c677-47d0-817d-4d10d123ad7a
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "641"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 754429d9-1e8d-4e68-95f0-f2f073045455
+      - 3997e882-7de9-470e-95cc-e948922fb25e
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1466"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a303a1e-5c80-4cab-bc3e-c41f65eea49c
+      - 48724cfe-5398-493d-b287-e33c6d9c7935
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "665"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:23 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa52e1b5-b878-4740-b5e9-6ae8f447b024
+      - ae71416b-3005-4063-be82-acc8b9fa3120
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "708"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2960b4b-ae94-41ef-b56a-b697132809cb
+      - 5ce3c624-dcc9-4c4e-a6e9-d3b9a723d0cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1466"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cb44280-1675-4c42-b8e0-98abd0b50b13
+      - 9d1c2fe2-79b8-42cf-9355-5815210ac650
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2684"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64143625-7821-409d-96dc-39f014aaf554
+      - cb605bc2-73fb-4ad1-9e30-12176d4ab8f9
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "665"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95dd5b4-ab33-4a86-aa7f-932e83b27d28
+      - 52e8396e-2f1f-45a2-8cc6-1228be484176
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "641"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:24 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd104a4b-d71e-4b37-ba27-1066c8e511e9
+      - 3bc09f65-a921-42d3-96e5-40126787e667
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "708"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dce02f59-f844-4002-bff8-55e2ec9d0215
+      - d73f2619-29d8-4702-9939-de7241501f86
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1466"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d8d8b30-ed61-4ed3-8d87-fcd2b236eb57
+      - ea3efb4c-e65c-4943-8daa-6a60ae922303
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2684"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efcfae2d-595c-4c0d-89c2-e0eb8aa181a7
+      - 667f3a38-6dcd-4259-8c48-bfe891a4bcbc
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "665"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:28:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96f30b2f-1e4e-4b72-a335-b5ec0f823a73
+      - a72dec04-c5e1-4e2b-9f1c-3f9b69b90a15
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "641"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:28:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83f49bbc-1a56-4938-927c-bdb78d1139be
+      - 343da2da-7eed-4b33-a04f-4b2c5b78c80e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a97b254-f958-482e-96ca-3ea157cb75e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "659"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc0831a9-57c6-48a0-8b39-54b7622a1c32
     status: 200 OK
     code: 200
     duration: ""
@@ -2594,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: PATCH
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025191Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785756541Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "668"
+      - "693"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2616,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd2e94d2-165b-4ec8-b1a4-65fcfa9857f5
+      - 8d7c6ab8-bba1-4346-b81e-8c3b37006c4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff8ef6a-d493-428f-b8a8-4e30a66089c5
+      - e50f87cf-6a7a-40b0-ba13-04a391e4cb7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25e682b5-ef09-4830-89fe-da5c3a1f72ed
+      - 9b06f43f-cd71-4f71-bcc5-d14837bafc09
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3edd187-289b-4d2b-bcda-c128a584a5c8
+      - 024bc6c8-20fe-4474-acf5-7d0b04267f61
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1466"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c3396c0-b175-4383-b03c-e9970c0cd83f
+      - 3babd233-a5c6-4a58-9415-4fb305e50c5a
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:26 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ab8e56-a68d-468e-ae3c-88f9a6deb7de
+      - 08163227-fcd0-4cbf-8f46-258cbe92fec7
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "708"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:27 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e26eea2-ef1d-424a-9ad0-a14da17f8a28
+      - 0487bfa4-a585-4775-8e30-e66b04deef95
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1466"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:27 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a386b9c7-1b6e-4f6f-9b6b-754f71ca6ac1
+      - 70589c00-300f-4e08-a6f6-423d8d3172b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2684"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:27 GMT
+      - Fri, 10 Nov 2023 13:28:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98a02706-1c59-4133-8f42-c953b9d7cbc5
+      - 84c15e68-3b42-483d-b326-f5cecbbac5f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:27 GMT
+      - Fri, 10 Nov 2023 13:28:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2ea60bb-df28-4c1f-b3b5-17c3d18c2925
+      - 1b986224-0ac7-4a07-ac1c-3d24b8cf884a
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:26.674862Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:11.485377Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:27 GMT
+      - Fri, 10 Nov 2023 13:28:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9de414d6-5af5-49cb-ad8d-b390fa7bd0ec
+      - 2a4a22bc-77ab-46e6-9554-3d58345eea28
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068471899Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950169Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:28:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e8f4183-cf4e-4797-a947-5c2de0f1227b
+      - 6f7a5e01-a92d-4ec5-ab70-824692622607
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "668"
+      - "693"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:28 GMT
+      - Fri, 10 Nov 2023 13:28:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd1b505b-6d41-4383-b104-7f0318cd5674
+      - 48cbce76-b5b1-45ab-a92c-bda29f165922
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "668"
+      - "693"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:33 GMT
+      - Fri, 10 Nov 2023 13:28:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 019c8d0e-d001-46be-9bb4-c33ff3d9df1a
+      - ea98b76d-6d75-4878-a662-ffd80ae9e050
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "668"
+      - "693"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:38 GMT
+      - Fri, 10 Nov 2023 13:28:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b09babe5-8c20-42dd-93fd-c6f0bd714cef
+      - 263291ea-c062-44bd-bc42-faeb61f4f500
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "668"
+      - "693"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:43 GMT
+      - Fri, 10 Nov 2023 13:28:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 143dae80-35f8-48c0-8a7c-fd185b7d1f17
+      - c5340b07-d762-44a9-bdcd-ab3e20bfe1a5
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,10 +3188,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f61094e-851c-49ba-ae5f-2881ba143da7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3134,7 +3233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:28:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6cfc4e5-61c0-4b55-9230-b47def6ed2cf
+      - 66f95cfd-7cb9-4c36-b235-08132c44ae01
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3155,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376430655Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237160Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1472"
+      - "1517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:28:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c27726ce-f6b5-4d95-968d-a55cab0afcc6
+      - deb103b9-d006-4763-a4d3-c9299ef43eda
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376431Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1469"
+      - "1514"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:48 GMT
+      - Fri, 10 Nov 2023 13:28:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c99c735-cb22-474c-bd20-b12eecadf3e1
+      - 4e43e535-04d0-43ec-8bcb-9b7bd19cf1bb
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376431Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1469"
+      - "1514"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:53 GMT
+      - Fri, 10 Nov 2023 13:28:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68c9191a-1e21-4665-a052-05ff476f3978
+      - 74d1d32a-9e16-47eb-a618-7610fd875884
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3266,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a344887-a164-4482-9c9c-575f4e893e9c
+      - f314e888-0341-4ff0-9b67-7c3c415833c4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3287,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3299,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13fdfb35-9a5d-4f51-b0ba-944565d3a8ee
+      - 0d813436-51c0-4125-91d1-e8d25d80d26e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3320,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:58 GMT
+      - Fri, 10 Nov 2023 13:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3441,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5719170-acbf-4506-b764-1ac2e62f19e1
+      - 171b804d-9e86-4984-9894-d1c4131951d0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68004be9-1b30-4a19-ab28-674d6eaf8416
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:28:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e966aeeb-887b-4cfe-98c8-0a00c56039bd
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:48 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01e0bb02-5868-48f5-bd27-6938fb757e03
+      - 76c36606-08f6-415e-bccc-4cb6ddd648f4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-wait","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-pool-wait","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24559032-3996-40d8-9cd9-deee7b7f7ed5
+      - 75d99bdf-ffe4-472e-bee1-82691d642b87
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40177934-0356-4711-9351-942234c2661a
+      - 55560b99-1e5a-497b-9702-9b4dc0b05ed3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393484Z","created_at":"2023-11-07T15:49:52.856393484Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:52.868916169Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901389Z","created_at":"2023-11-10T13:16:58.936901389Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.991811604Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1461"
+      - "1506"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:52 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cc55ff8-d33f-470c-9c9d-5a1b2271b713
+      - 6be808d9-780c-40f0-8384-4ae9791810a2
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:52.868916Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.991812Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:53 GMT
+      - Fri, 10 Nov 2023 13:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e575cf1-a919-4291-9701-00bed879f907
+      - d9813709-0306-4138-a952-810f486eea6f
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1457"
+      - "1502"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e6473aa-825f-4816-add5-0db10cadeafe
+      - f7df967c-791e-40c5-a074-ce3b9e20ce50
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1457"
+      - "1502"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03817c0f-d09c-41ac-952f-6028ac257680
+      - 2d4f59e8-b639-4246-9e34-30647f43fe8e
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b53d15d-a895-42af-b50a-b7dfe3b4a882
+      - 69b64b11-8099-4a4b-9c04-ce7288446566
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1457"
+      - "1502"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c16ca7e2-16d1-4ead-bdcf-fecd24a4f48e
+      - 833dbe79-afce-40af-922e-bceca20037b8
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342692758Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461657749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4704cecd-4846-4cb1-a1d1-847742590fc1
+      - b50493c4-6553-4685-a46e-4ace4c692778
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:49:58 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e19dc9c6-8919-4f9b-bb8e-8891af68cd60
+      - f1845e72-c976-4c0a-ae4d-419b1ea8db02
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:03 GMT
+      - Fri, 10 Nov 2023 13:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dffc0ee-47cd-49bc-a86e-751d5a1e04e3
+      - 9078d3bf-0598-4d70-a476-a8d724ff0954
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:09 GMT
+      - Fri, 10 Nov 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e95efbc-d2d4-4a6e-8c59-6fafb0c59996
+      - 9e03ca22-d670-4e8f-8119-43151923a6da
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:14 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f237bb0f-1c9f-4697-972d-83ed8e7a8913
+      - d8fdd274-2fb3-45c9-8f6f-7386c8ddf8c2
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:19 GMT
+      - Fri, 10 Nov 2023 13:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - def8e7d1-4ed7-478c-8d33-0b8b8f68359b
+      - a6ffa5b4-a7b5-4e52-aa36-cfab7c1c5bf3
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:25 GMT
+      - Fri, 10 Nov 2023 13:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d2ef50c-5bdb-43ec-9425-2512baf78f5e
+      - 5d821872-4481-4e84-859d-75ab4da0d90e
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:30 GMT
+      - Fri, 10 Nov 2023 13:17:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1a4bc90-9c40-48fa-a0dc-af4f4ee2051d
+      - 80d3252c-f2c0-4b4f-834f-915ff5e90e53
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:35 GMT
+      - Fri, 10 Nov 2023 13:17:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8d478d9-cc2a-4831-9789-83781bc01bc8
+      - d68eab84-25ba-414e-a867-950b33e446df
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:40 GMT
+      - Fri, 10 Nov 2023 13:17:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e033a88-0cfe-460e-a8c7-b5b748487141
+      - 23f5f7f6-9897-4106-b6fc-160e2f40fb1a
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:45 GMT
+      - Fri, 10 Nov 2023 13:17:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a350b6d-32fd-4379-9999-0b6a03528b3a
+      - 4184929f-a83f-41dd-a71d-4ef37e530deb
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:50 GMT
+      - Fri, 10 Nov 2023 13:17:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f78cd00b-1121-4949-8ee2-9175e1b798c7
+      - 79420198-60f8-4702-9fd2-b314d3381eca
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:50:55 GMT
+      - Fri, 10 Nov 2023 13:18:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52297e1c-f3fe-413a-9a51-ff57e7c7c69c
+      - 4dac2fc1-dd65-449d-821f-638f8f61f125
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:00 GMT
+      - Fri, 10 Nov 2023 13:18:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b2b4b39-2710-4949-8eab-d463f24cca09
+      - 153f105e-257d-469f-8f1f-364b5cf94a8d
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:05 GMT
+      - Fri, 10 Nov 2023 13:18:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e8b5fcf-2c36-4620-b0cd-dc0156115f68
+      - 86057476-3e8b-4b2a-87e2-018cf678ae01
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:10 GMT
+      - Fri, 10 Nov 2023 13:18:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cda6119-147f-43db-8610-2ef9c7aca96b
+      - 2143ad48-383f-44a2-b243-1ff132516636
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:15 GMT
+      - Fri, 10 Nov 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf6eb20c-46ca-4e4b-b6d2-8c060721040a
+      - 4f51b781-dbe5-4ffb-9a1c-a8bec5d59d72
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:20 GMT
+      - Fri, 10 Nov 2023 13:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8da99df2-70e0-4d9e-9924-9a3b1ee0c6bd
+      - 4a8f27a6-3529-43fe-89e7-a2f3b0fcf296
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:25 GMT
+      - Fri, 10 Nov 2023 13:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbd7ca64-1639-4da7-b62e-6c3c9746af90
+      - 406ff31c-4874-4263-a6c6-aea3bc0e6a9f
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:30 GMT
+      - Fri, 10 Nov 2023 13:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9deeead3-1cb3-4976-8d91-b33f45fcc6ec
+      - 0de53903-6510-41ad-95f8-0620d4f8613f
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:36 GMT
+      - Fri, 10 Nov 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90e0d800-2360-476b-a047-d6f70d08a891
+      - 432d07f2-7dda-4460-9ac1-735797d52698
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:41 GMT
+      - Fri, 10 Nov 2023 13:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d5ba2e6-b41f-4fe9-ac87-084de48c39e9
+      - 03ba0ecb-68d0-4ec7-bc37-3092bf6d28f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:46 GMT
+      - Fri, 10 Nov 2023 13:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7e78499-fc2a-4cba-b672-1b5a5dfcd9f1
+      - 0c461edb-eed5-41d2-abeb-4f35851ae1d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:51 GMT
+      - Fri, 10 Nov 2023 13:18:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf04bf85-48cf-43c0-8a9d-08720b5743b3
+      - d442e039-e498-4f36-9500-2afa01e13604
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:51:56 GMT
+      - Fri, 10 Nov 2023 13:19:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51f93fe7-e163-481c-b2f2-a16fb04e387a
+      - 99251777-e949-4de7-974a-706e5ca4c252
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:01 GMT
+      - Fri, 10 Nov 2023 13:19:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7992e0b0-2a51-4f54-9e6d-782b0b101ae5
+      - 014c4e6d-211a-425c-8b2e-361077fbba66
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:06 GMT
+      - Fri, 10 Nov 2023 13:19:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04e756e8-7ce1-4aba-806b-86f37da77343
+      - 408159b9-ab88-4fb0-ae88-c5defc018c55
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:11 GMT
+      - Fri, 10 Nov 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b048609-39b0-4cc3-8f8a-1f6f64e93558
+      - 995fab4c-c0c0-4346-90a4-fa4acd7b6f69
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:16 GMT
+      - Fri, 10 Nov 2023 13:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c3d2a9c-9456-4afc-8bf2-248569f8b3c8
+      - 50ece3a9-4d23-4da0-8ad3-ffda30360d7a
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:21 GMT
+      - Fri, 10 Nov 2023 13:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb03340b-8fc9-49cd-9da3-866b3611dbb5
+      - 6ee6f3c4-1d25-49df-a949-7cdc4fb9329c
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:26 GMT
+      - Fri, 10 Nov 2023 13:19:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a46b3ff-9ffe-470d-a8f1-4a5ee5f8b133
+      - 06ce63e1-d922-49b6-ae7f-751e479d4eb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:31 GMT
+      - Fri, 10 Nov 2023 13:19:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 022c41a7-0f3e-465d-80bd-911b2d3fe565
+      - 554cdb1e-67c2-4919-bab2-98383f84aa06
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:36 GMT
+      - Fri, 10 Nov 2023 13:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ba560be-db7d-4c84-a22a-ff6d0b94f416
+      - 763f9010-862c-4300-bfd7-9ac11b25dad5
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:41 GMT
+      - Fri, 10 Nov 2023 13:19:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7487b51-9197-4b06-9683-4c8a0eba4873
+      - 5e336972-dd2d-478b-bddd-10488a7dfd1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:46 GMT
+      - Fri, 10 Nov 2023 13:19:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20b468e3-4a16-4a14-8cc6-9f2148a13af3
+      - 93c052ef-2d2c-4dc0-956c-e562cce650ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:51 GMT
+      - Fri, 10 Nov 2023 13:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33fde6b4-06a2-44a1-a8fb-407ccbef35af
+      - 717e9b4d-520d-471a-a9d4-d39d9420a880
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:52:56 GMT
+      - Fri, 10 Nov 2023 13:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b7752a4-e1df-4ccb-bc7e-4100437f58e8
+      - 6b77d42f-4317-4c31-b0b8-d6d4aac82f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:01 GMT
+      - Fri, 10 Nov 2023 13:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d10ffd2e-3ea0-49d1-afd5-681630234037
+      - d15fa80d-feab-474d-9d2f-5b787a7d96cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:07 GMT
+      - Fri, 10 Nov 2023 13:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be006c70-c10c-4f11-9825-33047eec7b8e
+      - 4cb16a8c-d150-4cec-ae60-ad2f5ab10df9
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:12 GMT
+      - Fri, 10 Nov 2023 13:20:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 199fcf78-d0ed-42fa-8893-405eef72d8e1
+      - 58bf7aa8-5ba4-43f9-8e97-13a0567b8af9
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:17 GMT
+      - Fri, 10 Nov 2023 13:20:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c6ca505-c566-4ffb-b813-a85b10ca81f7
+      - 77bfa0ab-cbed-4ed9-95e8-80df7d610f29
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:22 GMT
+      - Fri, 10 Nov 2023 13:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7954b6ba-cfaa-402b-a888-1ca537f5c1dc
+      - f321443e-b9af-4bae-acd3-a8b8800845c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:27 GMT
+      - Fri, 10 Nov 2023 13:20:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0da2ef17-820d-4e58-8998-338559aa9098
+      - 915b4fb5-2d48-4e43-9723-dd49df33e7ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:32 GMT
+      - Fri, 10 Nov 2023 13:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1b94b5f-49ca-4f10-a6ba-38cced9aa8e0
+      - e1f2745b-6df3-4d4e-9a6c-d3fba312117b
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:37 GMT
+      - Fri, 10 Nov 2023 13:20:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53b3acb6-9df5-4541-8674-ff96f35967ed
+      - 8f4e6eef-ee00-4dc6-93b0-7edb64383de0
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:42 GMT
+      - Fri, 10 Nov 2023 13:20:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82801bca-9de9-47e3-aedc-a21fbfd6fbdc
+      - afdd5f07-c482-49d6-99d1-d0cdd85e26d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:47 GMT
+      - Fri, 10 Nov 2023 13:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d5af4ac-62f0-4d7c-8a79-5ab5dd97405d
+      - f31ef0f6-ce2e-4036-aabe-9ced46074805
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:52 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9495ced-26b5-4575-b451-8a256a23a10d
+      - d3a60a1d-38b1-419e-a370-977159d087c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:53:57 GMT
+      - Fri, 10 Nov 2023 13:21:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dafa23d-5b6c-43da-9300-d441f04371a8
+      - 6676671e-9f96-47b5-92e2-f1aed33769da
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:02 GMT
+      - Fri, 10 Nov 2023 13:21:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d629c838-54a2-44b3-8a1b-d82573d1adf1
+      - 1c137735-54da-41d5-84fc-531c0703498a
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56abe6c-e613-445c-a268-64efa7eb8bf6
+      - 1c7dd682-7d55-4e82-a1fc-a3e773cc3640
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41de0c41-db67-485b-9871-90d2a85bad35
+      - 159b4efc-7640-4cd2-a81a-99f632e46812
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1be02c55-cd73-4eea-b005-5d1bd6231686
+      - bbe63c32-320a-476a-b8ef-58871609ae28
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09620a8f-6bbb-40c4-828d-2c3765641b2d
+      - e3699913-71a7-470c-9c97-c22d4d070afc
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f1aa057-fe65-4cdd-b01f-dc8d153cdc47
+      - 6c1e0c97-1934-45b5-acb3-237e6ee3e2de
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:07 GMT
+      - Fri, 10 Nov 2023 13:21:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6976d16d-0e92-453f-9147-9ee426fb1d70
+      - 547aada8-b968-40e2-9593-825a423de9ea
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "698"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9544a56-36ea-4a25-830a-5de74edbe774
+      - 8863d9b5-b6e9-43b1-acb3-e7baa809e8f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:21:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ccc84d4-d14e-4b14-af9c-b584b75159e5
+      - 08431446-2299-403c-9ed8-c51bdad513da
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2604"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4048b70-8904-4495-b4ed-5a2dd00297a4
+      - f704fc4f-4155-4538-b7ac-026b513eff2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:21:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75ce8c46-cef3-4147-88d5-68426739833b
+      - 0c450a49-7f31-485d-926a-476a1ea61f6b
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:08 GMT
+      - Fri, 10 Nov 2023 13:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93684b6e-64d8-462c-b302-d7e6a0d4f425
+      - 0dc868a5-03a0-4377-92a9-84364386ff4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "698"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:09 GMT
+      - Fri, 10 Nov 2023 13:22:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca6d1c3d-26cf-4e75-b560-d75b4e1b173e
+      - d0d1a4f2-35ad-4177-a07e-ac7b331fa79c
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:09 GMT
+      - Fri, 10 Nov 2023 13:22:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5db6a193-c5e9-40e1-baff-43db519e6aad
+      - 56d89ce4-fc1d-446a-8b29-fe87e9e3eac2
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2604"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:09 GMT
+      - Fri, 10 Nov 2023 13:22:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d38076a-8bad-4a74-adee-030bff5e475f
+      - 5f9b15c2-f0c0-4597-9d33-c923ef9a31e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:09 GMT
+      - Fri, 10 Nov 2023 13:22:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9030a5e3-8498-4c6b-89e9-d534e22bbaf5
+      - 550f7333-b521-4da6-8fff-99e22c7810ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:09 GMT
+      - Fri, 10 Nov 2023 13:22:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bb75f4d-55e4-4e3d-8e49-074d36f5e62c
+      - 0f6deb07-6b5a-42a2-8a0f-100d8f48e8d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:10 GMT
+      - Fri, 10 Nov 2023 13:22:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,964 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c5b8163-fc9d-4f59-878a-2f9b2714ac3a
+      - 817446fb-d707-45bf-84d3-c8e2e6024c28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b2e5483-5327-4afe-add1-cf89aa235dea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7629de44-96e1-44eb-a799-208706ec7453
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2d9e4a3-39ea-477e-8218-e25de6cbebd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 732af5f1-affa-459f-8bc9-bd4639d23644
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26caf299-6eb1-46de-b573-5c3651c0561c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fcdcf943-9132-473a-a656-8a75450186b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec644d80-9b3d-45a8-b83f-cd1329f70f09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99e70a9e-eaa9-4bb1-b659-95196c690627
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59ecee0b-70fd-4891-bff5-c912b2eed21d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac1175a3-fd34-4ff2-b165-46d49c2a296a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd5e993e-8420-4dab-90f7-259229d71a4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 241dccd7-34ba-4fb5-9600-929e680bed6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7416a078-c7ec-4499-8c04-4347cee5d7f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aeddaa49-98e7-4797-8747-66c313efc46e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa92315f-308a-487f-9999-6379d8e9314b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4080f277-3fe7-451c-a353-77442e864c98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d12bd85e-4675-4867-b850-304042fe0091
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab90f275-5d82-4088-a18e-5494a3c8cf07
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "715"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c502beb-9266-48cc-9652-c632349c146f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62ff3d39-3d5d-4a43-a892-eae869e13641
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 91612639-2776-43fd-a439-d777a9aced84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77408e26-9ad7-4eff-8584-75399a702aa7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d4e4f27-656b-43ca-8ded-a2e6996522f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "715"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - acb9223b-b407-4b9f-9ef9-5886a6dcb609
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed97d978-98dc-4770-a11a-2748a6e14928
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9a0e3a2-8c4b-4ada-9ecf-25ee9de9d7ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "624"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed89c2dd-17aa-4c2c-8c6f-59853718b961
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b0932f0-3c2e-4ade-8606-7d082522629a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cff028b5-5f8c-43c2-950e-9a87dcb73cf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2528,19 +3485,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130860643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148621824Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "608"
+      - "631"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:10 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2550,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 822d6b1a-3420-40a0-a1ad-5ef7e3a33bb9
+      - db6be453-0d21-4595-b8f8-203c627aa3e0
     status: 200 OK
     code: 200
     duration: ""
@@ -2561,19 +3518,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:10 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2583,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 467cd6bd-cdaf-441e-8a46-8000ac29203d
+      - 792d10ce-2668-426e-89e1-14c9c37ba369
     status: 200 OK
     code: 200
     duration: ""
@@ -2594,19 +3551,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:15 GMT
+      - Fri, 10 Nov 2023 13:23:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2616,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c3becb3-2130-400c-9d70-93f73f67e9c7
+      - 8393c341-909a-4bf0-a756-582b670dcaed
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,19 +3584,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:20 GMT
+      - Fri, 10 Nov 2023 13:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d988b97e-dd19-454d-8f0f-84c7c4f3098e
+      - 206a7ca5-085e-46dc-ada5-63f6386845b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,19 +3617,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:25 GMT
+      - Fri, 10 Nov 2023 13:23:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1e8fcc8-6aad-42d0-a20d-a4d673d89da1
+      - 7ca45b1c-9351-4665-9831-c971a398535d
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,19 +3650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:30 GMT
+      - Fri, 10 Nov 2023 13:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be19537-3198-433d-9c50-92cd2f50ae9a
+      - 80b0ef5b-1872-4a7a-aec8-f25413b26d96
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:35 GMT
+      - Fri, 10 Nov 2023 13:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8294d09-e65b-45b6-93f2-ec3a628ea83a
+      - 1feb2a17-f775-4405-b089-eda93702f63c
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +3716,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:40 GMT
+      - Fri, 10 Nov 2023 13:24:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4af5647-d449-46ac-941c-48fdcc99ffa4
+      - 170be4fd-38c4-4166-b27a-6a2eb8c62cb6
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,19 +3749,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:45 GMT
+      - Fri, 10 Nov 2023 13:24:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b04d5d0-d2c0-467d-aac2-2474b890b78c
+      - 870576bb-dccf-48c1-83e4-ee0c1e4613a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,19 +3782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:50 GMT
+      - Fri, 10 Nov 2023 13:24:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd0d3fdc-03a8-4691-8193-2ab495fbdd92
+      - 3eaff1b1-c340-4395-8687-1473a95d928d
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,19 +3815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:54:55 GMT
+      - Fri, 10 Nov 2023 13:24:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82424cd4-5bd0-4785-a390-1dbad4eb7714
+      - b5cfb4a5-1b31-4b4f-9c8f-7ac8fd1892a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:00 GMT
+      - Fri, 10 Nov 2023 13:24:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a08ff07-479e-48b1-8350-12eee8ee05a3
+      - a2cdbd5d-6a95-4b3e-8fcc-bf8d63766699
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +3881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:06 GMT
+      - Fri, 10 Nov 2023 13:24:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa084ab7-494c-4248-8f9a-abe04549c6e3
+      - c55ad2b1-b824-4b64-b269-0fe304bfc6bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +3914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:11 GMT
+      - Fri, 10 Nov 2023 13:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69b8d107-9445-482b-999c-da8f7b0c7d34
+      - ba6fdcbd-1602-447b-8e37-ba95747fe51b
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:16 GMT
+      - Fri, 10 Nov 2023 13:24:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec3bd6f3-5571-4281-b06d-b7ae94deb480
+      - 79093cb8-37f4-433e-a287-9c627bf092fb
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:21 GMT
+      - Fri, 10 Nov 2023 13:24:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7bc1c5b-458b-4eb8-99d6-a6eb4edcc456
+      - e471e3a8-61bd-4634-a841-dd76672e7e32
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +4013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:26 GMT
+      - Fri, 10 Nov 2023 13:24:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5629aaa4-6363-449b-bfcc-1d5974afd3bf
+      - ca62cbc3-a47a-4613-bec2-b49a7265aaa5
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +4046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:31 GMT
+      - Fri, 10 Nov 2023 13:25:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165e1cd9-f88d-4859-98df-333bcbb61230
+      - 68a4c981-4be3-4ee3-922f-1837fddb2a0c
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,19 +4079,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:36 GMT
+      - Fri, 10 Nov 2023 13:25:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1611fbb-1f9a-4e54-87d1-02110ee952d6
+      - 82a59f89-0e81-42a2-9a9a-6bd339b9d6a7
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,19 +4112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:41 GMT
+      - Fri, 10 Nov 2023 13:25:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f9d93a-a7de-4262-95ba-b1e318c1f6fb
+      - b3c5036e-edc5-4cba-aa7f-6a96bf68af33
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,19 +4145,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:46 GMT
+      - Fri, 10 Nov 2023 13:25:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da6d508-2902-4c9b-b83a-e36534f00719
+      - 6dce1d85-49be-423e-8a62-a24c7e86b506
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:51 GMT
+      - Fri, 10 Nov 2023 13:25:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de865b64-7258-47c6-8fa0-3dbb990ae890
+      - 378e6133-5422-4f7c-887d-3bf021e105e7
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,19 +4211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:55:56 GMT
+      - Fri, 10 Nov 2023 13:25:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf92e297-12c8-49af-b421-06912464cae1
+      - 60b7f5ff-1559-444d-9077-2a5b3b369c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,19 +4244,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:01 GMT
+      - Fri, 10 Nov 2023 13:25:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20f910b1-ae70-4a59-ba76-45acfd2fc97c
+      - 8e1b6d68-8892-49e5-bc5c-9697d8cc9d71
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,19 +4277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:06 GMT
+      - Fri, 10 Nov 2023 13:25:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab7bdd82-bff8-4a52-9ca8-9a28d76a0827
+      - 819a687d-0336-493c-a691-4cddb974cd3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,19 +4310,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:11 GMT
+      - Fri, 10 Nov 2023 13:25:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 860d836a-7942-4d82-89f3-b4dd0cdfb500
+      - ce04ca46-b5b5-4d1e-b0ac-2e582ed09563
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,19 +4343,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:16 GMT
+      - Fri, 10 Nov 2023 13:25:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3b9bf3d-da77-4add-8636-15bba7044eea
+      - b7f05544-b421-4b5e-982b-17d64637571f
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,19 +4376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:21 GMT
+      - Fri, 10 Nov 2023 13:25:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71cabedd-b691-4e14-abb6-73453bf9a932
+      - 3c713be6-149b-4b09-a21f-3fab2615c22d
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,19 +4409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:26 GMT
+      - Fri, 10 Nov 2023 13:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58af6cd3-2467-4836-aa36-37d5c44b852e
+      - 1cde5a05-3cfd-4338-9fc4-f142c1a6892a
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,19 +4442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:31 GMT
+      - Fri, 10 Nov 2023 13:26:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb9d038-057a-4337-9d9d-7276e7f66e49
+      - 02fbf6d5-af33-4b9d-bf5d-25f944a89df2
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,19 +4475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:37 GMT
+      - Fri, 10 Nov 2023 13:26:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef73ab6c-8d38-43a6-9d6f-71caa16c4c65
+      - 3d2e9e05-42b4-4d1c-9f55-b64d507f3cb8
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,19 +4508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:42 GMT
+      - Fri, 10 Nov 2023 13:26:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3b86d5f-a08c-46dc-92d9-9b898e496a48
+      - a29e835b-a7ba-49e0-9589-54ef9e98b1b5
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,19 +4541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:47 GMT
+      - Fri, 10 Nov 2023 13:26:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +4563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0fc3b81-fd35-492c-9d66-209f341a0c2d
+      - 92faf42d-9cf2-4674-9089-eb74657f47ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,19 +4574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:52 GMT
+      - Fri, 10 Nov 2023 13:26:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +4596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a8c6eb4-ba97-4f96-b0b5-2a354ae60cb8
+      - fc690929-07a6-435b-ab30-9978c4661a0f
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,19 +4607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:57 GMT
+      - Fri, 10 Nov 2023 13:26:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +4629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baed0024-a3f2-476e-9b54-16556823a719
+      - ec09d018-3897-4848-a132-f32b658e70bf
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +4640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:57 GMT
+      - Fri, 10 Nov 2023 13:26:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +4662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3292e9d5-4625-4244-a0b5-65be636f4ac4
+      - 729106c9-6669-4afb-b1a2-ca04e3977466
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +4673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "640"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:57 GMT
+      - Fri, 10 Nov 2023 13:26:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +4695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7f1dfcd-e7d0-442a-a6ce-bd8536f6c5ab
+      - ac833d34-b778-4f0d-afed-23549d63dc47
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,19 +4706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:57 GMT
+      - Fri, 10 Nov 2023 13:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +4728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b1054b7-403e-4a39-8652-b96d454ffc87
+      - 24514c0c-56ed-428b-8812-4ae8f1927942
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +4739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:57 GMT
+      - Fri, 10 Nov 2023 13:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +4761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a6635a7-0319-4619-a8bb-6d129da4fe78
+      - 9bae320b-b0c7-4df8-b560-da3dfd29c8d3
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,19 +4772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "698"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +4794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f66eed45-7c3d-4bbc-8792-a36e97a423da
+      - 4470b199-6759-45ab-9245-d7fb5cdeee6d
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,19 +4805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +4827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32d8f530-d9c1-46a8-a1ed-f72849225264
+      - 6b74a274-57f9-47ee-be2c-39c2f6ab1f85
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,19 +4838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2604"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +4860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9035a91-14a1-4c18-93d8-4749be50e4e3
+      - 9b0e4423-c937-4db0-9f71-75f00e20a3ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,19 +4871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "601"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +4893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcdbac11-9d7a-46fa-bae5-4a07e0af6802
+      - 27492c08-5eea-4285-ae69-dd7e99c734aa
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,19 +4904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "603"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +4926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e590bfc5-5d58-4224-b008-0693ea650f52
+      - f72a4c3d-e293-4f31-acf2-ef10311607e8
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +4937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.823191Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "670"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +4959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3469f668-f6e5-456d-8cc9-f3e73e53a5b3
+      - be75ac68-aca3-4826-818f-f56a4a3d5a7b
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,19 +4970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "640"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:58 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +4992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fc2b9ec-616c-4131-96cb-7b86ce40ebb6
+      - a2cb5d18-d8c9-493f-a429-800cee8d4e04
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,19 +5003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "698"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +5025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c11b455-e60e-473c-b7b2-3568f133d604
+      - 9c013fe8-b917-471f-8280-4d2c0eec854a
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,19 +5036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1449"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +5058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3553896-3e7a-42a6-b14e-b299f8aefe6a
+      - c17b4146-c7b6-45d8-a1ae-c2acee25cda0
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,19 +5069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.041882Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2604"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +5091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df7af52e-f3c8-401c-a78b-dd5f50880956
+      - e492db75-6f5a-4056-8fe9-24c789fef2bc
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,19 +5102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "601"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +5124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5fe7137-1b54-4458-94f1-c2dd01834ab9
+      - b9bdf179-f079-4cb0-9423-d4aa4068466a
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,19 +5135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "603"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +5157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97c99332-b186-4414-a248-1571c5f5d0f5
+      - 9e30738c-87d0-4ae1-acdc-807827b8bc48
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +5168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "640"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +5190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dabe6dd9-2e92-4b93-bbff-cc095e258acb
+      - 7d91407f-23b5-492e-9679-bf480f138f76
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,19 +5201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.823191Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "670"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:56:59 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +5223,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caba84ba-563c-44c5-954c-9e65e347bfc5
+      - cedf8ae8-4422-49ff-ae13-b400c5001dfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 025deb0c-ee62-4a94-851d-ff0ba2fce60e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "659"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 234319e1-0742-454d-a583-9fde4bbc5ee4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.041882Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:26:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9917d24b-db0b-4570-91a7-88fd323ebd04
     status: 200 OK
     code: 200
     duration: ""
@@ -4279,19 +5335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347345Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "608"
+      - "631"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:00 GMT
+      - Fri, 10 Nov 2023 13:26:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4301,7 +5357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6797ab3d-c6d9-4b73-9de6-140a79fc4b26
+      - 23224f3b-7f7a-4cba-a02a-032fcba536d0
     status: 200 OK
     code: 200
     duration: ""
@@ -4312,19 +5368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:00 GMT
+      - Fri, 10 Nov 2023 13:26:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4334,7 +5390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad72bac-8bc2-46e6-9c95-1b52ac76a140
+      - 1e4d6547-cac6-4744-a4e0-3bcc5283a04b
     status: 200 OK
     code: 200
     duration: ""
@@ -4345,19 +5401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:05 GMT
+      - Fri, 10 Nov 2023 13:26:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4367,7 +5423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3f05bc7-5f9b-4452-84f4-a13f2be91a33
+      - 71d92c0d-1207-498d-a73c-4a984457e875
     status: 200 OK
     code: 200
     duration: ""
@@ -4378,19 +5434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:10 GMT
+      - Fri, 10 Nov 2023 13:26:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4400,7 +5456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9d6b8c5-a6c1-4d4d-bb23-86eb0c8ad0cf
+      - 20eeb269-f159-4645-8b9d-662dc946fcac
     status: 200 OK
     code: 200
     duration: ""
@@ -4411,19 +5467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:15 GMT
+      - Fri, 10 Nov 2023 13:27:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4433,7 +5489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c28f4c3c-c586-47d5-88ec-434778bb07b5
+      - 9dcc85d9-913e-4be5-b720-f681ab84207b
     status: 200 OK
     code: 200
     duration: ""
@@ -4444,19 +5500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:20 GMT
+      - Fri, 10 Nov 2023 13:27:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4466,7 +5522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c340624-f354-4dad-87e9-7824048ae0e6
+      - 6d69d860-cbca-454e-8294-8ed1e42e812a
     status: 200 OK
     code: 200
     duration: ""
@@ -4477,19 +5533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:25 GMT
+      - Fri, 10 Nov 2023 13:27:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4499,7 +5555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0817e542-4336-4804-8253-b4edfd2be9f4
+      - 5d3f4065-2f6e-4218-83f2-47833dc290f6
     status: 200 OK
     code: 200
     duration: ""
@@ -4510,19 +5566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:30 GMT
+      - Fri, 10 Nov 2023 13:27:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4532,7 +5588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c1ce8cb-611a-4a8d-9944-cfac35922d33
+      - 06d6cdd0-a5e9-47fb-bfd2-930257b5edc5
     status: 200 OK
     code: 200
     duration: ""
@@ -4543,19 +5599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:35 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4565,7 +5621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43007b27-6792-4efc-8d3d-923be42f1dd0
+      - a6ef61a3-541c-46be-afee-33ebd1cedb47
     status: 200 OK
     code: 200
     duration: ""
@@ -4576,19 +5632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:40 GMT
+      - Fri, 10 Nov 2023 13:27:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4598,7 +5654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b827224-0754-4bdd-ba0f-7a5e6931669b
+      - 88387d4e-f76b-4a18-a675-dba855bf16f3
     status: 200 OK
     code: 200
     duration: ""
@@ -4609,19 +5665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:45 GMT
+      - Fri, 10 Nov 2023 13:27:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4631,7 +5687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2e55f6b-b883-4aa3-84fc-8f64e2eff0aa
+      - 73c08e45-37c9-44ba-bd6d-1985e84fbe77
     status: 200 OK
     code: 200
     duration: ""
@@ -4642,19 +5698,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:50 GMT
+      - Fri, 10 Nov 2023 13:27:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4664,7 +5720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a68f236-5580-4b30-8900-7b31a3ac34e7
+      - 6dfdeb02-5026-41f4-b191-e2166fcf1a78
     status: 200 OK
     code: 200
     duration: ""
@@ -4675,19 +5731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:57:55 GMT
+      - Fri, 10 Nov 2023 13:27:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4697,7 +5753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f737eb1-73aa-4e79-a1fe-a87c3ed509fa
+      - 9c4ef231-f580-4839-ab4d-81751651d11c
     status: 200 OK
     code: 200
     duration: ""
@@ -4708,19 +5764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:00 GMT
+      - Fri, 10 Nov 2023 13:27:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4730,7 +5786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e018779f-0b92-4652-808f-0258260a8cb3
+      - 652eb8fe-8118-44d3-840b-4469782e0b4a
     status: 200 OK
     code: 200
     duration: ""
@@ -4741,19 +5797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:06 GMT
+      - Fri, 10 Nov 2023 13:27:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4763,7 +5819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1803e3dd-c887-4dfe-98fa-0bdbb836fe31
+      - a35b8742-9859-46a3-84de-7c928348a236
     status: 200 OK
     code: 200
     duration: ""
@@ -4774,19 +5830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:11 GMT
+      - Fri, 10 Nov 2023 13:27:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4796,7 +5852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a96c145-df5e-47f5-999d-f17e7b19cda9
+      - 7858d410-e83f-41fe-9c65-988815cba700
     status: 200 OK
     code: 200
     duration: ""
@@ -4807,19 +5863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:16 GMT
+      - Fri, 10 Nov 2023 13:28:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4829,7 +5885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bae30696-9576-40a3-bc7a-70dce1ab1e44
+      - 0821ffab-a518-4ce2-bca7-2a40a0480b70
     status: 200 OK
     code: 200
     duration: ""
@@ -4840,19 +5896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:21 GMT
+      - Fri, 10 Nov 2023 13:28:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4862,7 +5918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a06bbc20-8272-4a37-8b36-9f05197972b1
+      - 2d394e48-8783-4a13-8bd7-e5fea650a824
     status: 200 OK
     code: 200
     duration: ""
@@ -4873,19 +5929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:26 GMT
+      - Fri, 10 Nov 2023 13:28:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4895,7 +5951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 508e76b6-ea18-401c-8cfb-86321545f498
+      - 7afb6729-08bc-4c4e-a47f-0b63a662304c
     status: 200 OK
     code: 200
     duration: ""
@@ -4906,19 +5962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:31 GMT
+      - Fri, 10 Nov 2023 13:28:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4928,7 +5984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35b05845-08c2-4c21-99e7-21bdb9a32817
+      - aba94b2c-439c-44d0-af4b-4daa4e4c0ee3
     status: 200 OK
     code: 200
     duration: ""
@@ -4939,19 +5995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:36 GMT
+      - Fri, 10 Nov 2023 13:28:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4961,7 +6017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 432a1542-c5e6-4514-ada9-a4002c0cd0c3
+      - 363083c5-8191-4224-b2c8-c19e0c617b6b
     status: 200 OK
     code: 200
     duration: ""
@@ -4972,19 +6028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:41 GMT
+      - Fri, 10 Nov 2023 13:28:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4994,7 +6050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e895b64-0ac7-44f9-b5f2-65f84bd3687a
+      - dea8e508-124f-432c-834e-4c518297c281
     status: 200 OK
     code: 200
     duration: ""
@@ -5005,19 +6061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:46 GMT
+      - Fri, 10 Nov 2023 13:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5027,7 +6083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96905223-2400-4ff4-b24b-bfca3ec8765f
+      - 5952e096-32b8-40f5-bed9-9c3f50129800
     status: 200 OK
     code: 200
     duration: ""
@@ -5038,19 +6094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:51 GMT
+      - Fri, 10 Nov 2023 13:28:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5060,7 +6116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9a53397-232f-48a2-b3a0-001621757702
+      - da8dbc1f-604a-4b6d-a40f-75ae38208983
     status: 200 OK
     code: 200
     duration: ""
@@ -5071,19 +6127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:58:56 GMT
+      - Fri, 10 Nov 2023 13:28:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5093,7 +6149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2d382e7-6362-4ac2-baa3-b92cb1578f88
+      - a7683ae3-a69b-4772-97a7-cdca2cad4881
     status: 200 OK
     code: 200
     duration: ""
@@ -5104,19 +6160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:01 GMT
+      - Fri, 10 Nov 2023 13:28:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5126,7 +6182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcee67ec-7834-48db-8580-95863b1c72b4
+      - 55ead4ae-fe28-40df-bb98-83b4ada3f348
     status: 200 OK
     code: 200
     duration: ""
@@ -5137,19 +6193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:06 GMT
+      - Fri, 10 Nov 2023 13:28:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5159,7 +6215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81c9b2e3-d861-4b08-baf3-7a69fe97327e
+      - 19be0b8c-3bf1-444a-b3d9-f5f6d4541a95
     status: 200 OK
     code: 200
     duration: ""
@@ -5170,19 +6226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:11 GMT
+      - Fri, 10 Nov 2023 13:28:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5192,7 +6248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19b005eb-7d85-473a-a6ab-4cacffd46eb7
+      - 3bcc8e8c-08ee-4abc-bd48-e4283d593b74
     status: 200 OK
     code: 200
     duration: ""
@@ -5203,19 +6259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:16 GMT
+      - Fri, 10 Nov 2023 13:29:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5225,7 +6281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faa95776-f0fc-49bf-8901-39b4e3b81525
+      - f052d73e-9410-4edd-aee4-149726547a1d
     status: 200 OK
     code: 200
     duration: ""
@@ -5236,19 +6292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:21 GMT
+      - Fri, 10 Nov 2023 13:29:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5258,7 +6314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c5b1bc-f932-4b4e-8d0c-ba13b83a402e
+      - 507185e9-022d-4c51-a077-c6ae73c7ab15
     status: 200 OK
     code: 200
     duration: ""
@@ -5269,19 +6325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:26 GMT
+      - Fri, 10 Nov 2023 13:29:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5291,7 +6347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f764488f-8835-4d03-93f5-174cb3b6115f
+      - ff6ae8a7-6f1f-478f-a7d8-175251a6c2a6
     status: 200 OK
     code: 200
     duration: ""
@@ -5302,19 +6358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "605"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:31 GMT
+      - Fri, 10 Nov 2023 13:29:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5324,7 +6380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2c75594-d97e-40f0-b8af-50326a44aad5
+      - b614f376-e255-4526-b3b3-cdb19ccaeb42
     status: 200 OK
     code: 200
     duration: ""
@@ -5335,19 +6391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "605"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:36 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5357,7 +6413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a3af0c-15d6-4acd-b395-7b8833dace27
+      - a4e258bf-7552-4308-ab9c-9bd7138c0832
     status: 200 OK
     code: 200
     duration: ""
@@ -5368,19 +6424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:42 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5390,7 +6446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7b88a67-8e49-4de0-8fde-9ead5e5b6d71
+      - 1b32dd38-5dcc-4276-8256-9c81899865aa
     status: 200 OK
     code: 200
     duration: ""
@@ -5401,19 +6457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "605"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:47 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5423,7 +6479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72622db3-a2bf-466a-9f6b-c450a78f005e
+      - be2b92d8-f262-468b-abf8-3ff5363074c7
     status: 200 OK
     code: 200
     duration: ""
@@ -5434,19 +6490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "605"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:52 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5456,7 +6512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37acfcf6-c1e6-4fad-b57c-cf285e7ef6fc
+      - 228450c6-0b62-40f8-bfd4-2d6f6539c8b6
     status: 200 OK
     code: 200
     duration: ""
@@ -5467,19 +6523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "605"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 15:59:57 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5489,7 +6545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a10146a-8d26-4b13-948b-34715540e6ba
+      - faabce6e-40c4-40d5-9437-4239ea06cf27
     status: 200 OK
     code: 200
     duration: ""
@@ -5500,19 +6556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:02 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5522,7 +6578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bce613e-1563-4032-9285-b1b8a8524ace
+      - 68f1ef5a-3b46-4a82-8f0a-dd4acc3a47b4
     status: 200 OK
     code: 200
     duration: ""
@@ -5533,19 +6589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:02 GMT
+      - Fri, 10 Nov 2023 13:29:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5555,7 +6611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07ffaecc-65c9-4bae-89ad-69fe16678307
+      - b3ac5d08-ae28-4c8f-9ed2-52057c0ee63d
     status: 200 OK
     code: 200
     duration: ""
@@ -5566,19 +6622,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.191323Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1284"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:02 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5588,7 +6644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c6a71b4-d45d-4af7-9fde-a04d59cdacc4
+      - 3758b24b-28ce-4dcb-974c-e73f79429a24
     status: 200 OK
     code: 200
     duration: ""
@@ -5599,19 +6655,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1449"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:02 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5621,7 +6677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dfdbd6f-ff60-4ff3-b333-87ea7bff661c
+      - aeb9d1f4-177d-48f7-aeae-673c9481b931
     status: 200 OK
     code: 200
     duration: ""
@@ -5632,19 +6688,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "603"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:02 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5654,7 +6710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8091c6d0-0370-4048-93ee-d5f9e021aced
+      - 95e1edbb-bba6-4553-8f6d-88f536f9ea8e
     status: 200 OK
     code: 200
     duration: ""
@@ -5665,19 +6721,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "698"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5687,7 +6743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a81807e-8e64-4c43-b8d5-1b1653fbf6f4
+      - 9e902ce1-b9a3-461a-9c6c-1b019ccf875e
     status: 200 OK
     code: 200
     duration: ""
@@ -5698,19 +6754,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1449"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5720,7 +6776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bde4c28-124f-4dd0-9a02-50a940e62eae
+      - 31e2156d-defc-4cf8-a555-bcbbbea304d5
     status: 200 OK
     code: 200
     duration: ""
@@ -5731,19 +6787,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2604"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5753,7 +6809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 131a179d-fba8-4356-89ac-2ab6da587ecc
+      - 6ced6d22-7d05-4429-9cb8-2470be671f2a
     status: 200 OK
     code: 200
     duration: ""
@@ -5764,19 +6820,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5786,7 +6842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 755245cd-d64c-4ce4-a5bd-fc73441d01f3
+      - 0e247554-a7fa-4a5e-a7e5-f0f30e2fd761
     status: 200 OK
     code: 200
     duration: ""
@@ -5797,19 +6853,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.191323Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "603"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5819,7 +6875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0eee677-6f18-403b-a844-e3dbef5f7ac9
+      - eac0fba5-872c-4ede-bff4-b272593c5311
     status: 200 OK
     code: 200
     duration: ""
@@ -5830,19 +6886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.283032Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "670"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
+      - Fri, 10 Nov 2023 13:29:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5852,271 +6908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 559f3e72-86ba-422d-8a3b-b802c2720017
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bce3841e-823c-475d-ad08-07ede84c7766
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "698"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97d91e6b-fa36-4759-b6ea-6c0a7fba37ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1449"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 224aeb25-d700-4ada-8ba1-1b7396d2cc85
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4bb8bca-ce08-428e-96c9-606a094c361c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "601"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 91a88272-a290-4d37-8b2c-eb9e89fca414
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "603"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c178d091-7119-4feb-9209-40a714e44647
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2f8094e3-7e7d-4ba2-9c79-bb69dadf4d7d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.283032Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b53482e-1b3a-491d-9eee-a9898dc11f98
+      - 9c372936-c134-4dc6-b4eb-8d48ee08b72f
     status: 200 OK
     code: 200
     duration: ""
@@ -6129,19 +6921,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:00:05.546535340Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:29:12.595085928Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "608"
+      - "631"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:05 GMT
+      - Fri, 10 Nov 2023 13:29:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6151,7 +6943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7eba7107-02e1-4c6d-b930-c9ab8452c289
+      - f0c47ae6-ad43-488a-9ca4-ee66e63c70f0
     status: 200 OK
     code: 200
     duration: ""
@@ -6162,19 +6954,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:00:05.546535Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:29:12.595086Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:05 GMT
+      - Fri, 10 Nov 2023 13:29:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6184,7 +6976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62cd6ac1-8b1e-48cf-910a-828f50450c3d
+      - f82c676a-1001-4869-82ce-d6c29eb34440
     status: 200 OK
     code: 200
     duration: ""
@@ -6195,19 +6987,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:10 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6217,7 +7009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 198ef8bc-cc73-49e0-87f1-34d14ef27624
+      - 36b7477d-03e5-4ac1-8ee0-39a01c7301af
     status: 200 OK
     code: 200
     duration: ""
@@ -6228,19 +7020,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:11 GMT
+      - Fri, 10 Nov 2023 13:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6250,7 +7042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9365c041-34e1-4fd1-8074-9dc0794b5868
+      - 8073c00a-c69b-4196-a897-c7b3f6480872
     status: 200 OK
     code: 200
     duration: ""
@@ -6261,19 +7053,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1287"
+      - "1321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:11 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6283,7 +7075,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 791dfe34-95aa-46c7-9eef-71b60f9b63be
+      - 39792917-d3da-476b-a3cf-2b8b94e9323a
     status: 200 OK
     code: 200
     duration: ""
@@ -6294,19 +7086,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:11 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6316,7 +7108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16925a86-ce86-43a0-86fa-8e9ea7cc059c
+      - be36f029-c770-4c95-9fda-4a660b100580
     status: 200 OK
     code: 200
     duration: ""
@@ -6327,19 +7119,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:11 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6349,7 +7141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65f21baf-f0e5-493f-aa36-c2ad4279e8bc
+      - b6186106-018c-4c40-b32b-626d68de9afc
     status: 200 OK
     code: 200
     duration: ""
@@ -6360,19 +7152,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:12 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6382,7 +7174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 508efd6b-47df-492a-a84a-91ffaa0e0cff
+      - 833b8f54-b42c-47af-a77b-372434222aa0
     status: 200 OK
     code: 200
     duration: ""
@@ -6393,19 +7185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:12 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6415,7 +7207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eed03b31-1eed-4d54-87b7-e94fdade7556
+      - c47dfbda-94ca-4716-8151-2a7981415c00
     status: 200 OK
     code: 200
     duration: ""
@@ -6426,19 +7218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:13 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6448,7 +7240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad1f2344-d086-499c-8991-3a06896f71ab
+      - d09a4c92-e0e9-4ac6-8a01-70e00b1364b8
     status: 200 OK
     code: 200
     duration: ""
@@ -6459,19 +7251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:13 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6481,7 +7273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd187491-968e-4925-8c34-07f36611218f
+      - ab311b2c-4a00-4121-83f9-6e100252d849
     status: 200 OK
     code: 200
     duration: ""
@@ -6492,19 +7284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "603"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:13 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6514,7 +7306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71ea0fd1-25bb-4ea7-a5f9-ee6f0d755bdf
+      - bf78ddfe-1589-4dc5-892c-a1f83427d809
     status: 200 OK
     code: 200
     duration: ""
@@ -6525,19 +7317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.585129Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "670"
+      - "1321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:13 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6547,7 +7339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13805fa5-b066-4cfa-b5b4-ca126ab95e04
+      - 208454ef-130b-4d56-9a15-e764d4e163ce
     status: 200 OK
     code: 200
     duration: ""
@@ -6558,19 +7350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.723806Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1287"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:13 GMT
+      - Fri, 10 Nov 2023 13:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6580,7 +7372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2025115-6af1-4b93-9956-20d65b91bcb3
+      - 12b0079b-bcf7-4c81-bcef-96f5c39eef2e
     status: 200 OK
     code: 200
     duration: ""
@@ -6591,19 +7383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "698"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6613,7 +7405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf8fe6f3-a3eb-4cca-8abb-09b9dc01b558
+      - 24cdfafc-94bd-42c8-8cc7-8967137424b9
     status: 200 OK
     code: 200
     duration: ""
@@ -6624,19 +7416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "603"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6646,7 +7438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 012abab4-6f13-456c-b580-b7921e1994c1
+      - 14fd406b-7c10-4c5c-9ae7-a81460e305af
     status: 200 OK
     code: 200
     duration: ""
@@ -6657,19 +7449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6679,7 +7471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0efb248e-6aa4-4c1f-9cd4-04756e05afe5
+      - 432dd46b-d60e-44e6-ba17-6a2b47bc8b04
     status: 200 OK
     code: 200
     duration: ""
@@ -6690,19 +7482,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1287"
+      - "1321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6712,7 +7504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 822bb034-39c9-47e4-961a-1a9046f6398a
+      - 3077775c-07a5-48e1-86ce-d69904edae4c
     status: 200 OK
     code: 200
     duration: ""
@@ -6723,19 +7515,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6745,7 +7537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca3a5aa0-8fc4-4a8a-8111-d5aec900e5e4
+      - c8df7051-4f76-4077-9e41-ae21bb98a47d
     status: 200 OK
     code: 200
     duration: ""
@@ -6756,19 +7548,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6778,7 +7570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d898751d-88ef-4ce7-a00d-54f68c8140b4
+      - 9ed9cc83-b2b1-43f3-9dc9-10b4ff7c2928
     status: 200 OK
     code: 200
     duration: ""
@@ -6789,19 +7581,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.585129Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.723806Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:14 GMT
+      - Fri, 10 Nov 2023 13:29:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6811,7 +7603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ada9bec-7f7a-46b7-b607-db5acce59fb3
+      - 0effe3d5-c9d8-4334-b457-b1f07a12c44b
     status: 200 OK
     code: 200
     duration: ""
@@ -6822,19 +7614,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803335Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "609"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:15 GMT
+      - Fri, 10 Nov 2023 13:29:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6844,7 +7636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0593f85f-a24d-4321-9bd1-d924cbd6b26a
+      - 0d3be96a-89fe-4ffe-a4ee-1f37172fe351
     status: 200 OK
     code: 200
     duration: ""
@@ -6855,19 +7647,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:15 GMT
+      - Fri, 10 Nov 2023 13:29:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6877,7 +7669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e30fe6f-2a58-42e2-bebd-5df7ca60a086
+      - 14009c88-c0c3-46bc-9c28-268cd1466ca6
     status: 200 OK
     code: 200
     duration: ""
@@ -6888,19 +7680,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:20 GMT
+      - Fri, 10 Nov 2023 13:29:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6910,7 +7702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f30b27d-db1f-46f9-998a-8403cdf47fef
+      - aab05f39-b9d1-4589-86ca-63bdc95514f9
     status: 200 OK
     code: 200
     duration: ""
@@ -6921,43 +7713,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:00:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53afee9e-d6eb-4678-b838-f4feb3bb4544
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"df8f941f-0be3-4458-9318-77cde72cb43a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -6966,7 +7725,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:30 GMT
+      - Fri, 10 Nov 2023 13:29:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6976,7 +7735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69cde916-cbce-48f0-8723-c2c676ef1b71
+      - 02ec6f1e-c31e-409f-99cd-5e1616e89e7a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6987,19 +7746,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:30 GMT
+      - Fri, 10 Nov 2023 13:29:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7009,7 +7768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6214a99b-d770-42fd-ae11-0183f7a05700
+      - 3b86f25c-f42d-48a7-be5e-41b4fb900dec
     status: 200 OK
     code: 200
     duration: ""
@@ -7020,19 +7779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7042,7 +7801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2216ddf9-2578-498f-966c-f015c3b4efbf
+      - 54e13dd1-d7ba-40a9-8db0-f97a3a0da9dd
     status: 200 OK
     code: 200
     duration: ""
@@ -7053,19 +7812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7075,7 +7834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f5d54a1-bd1f-452d-9b98-42bd8fe09deb
+      - 4adb601f-0c22-4a84-9b79-ec4edde71223
     status: 200 OK
     code: 200
     duration: ""
@@ -7086,19 +7845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2604"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7108,7 +7867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8226b92e-2619-4cd5-9266-5ffef9402838
+      - 4e2eb6d0-a6e9-4117-8202-34a5fdc5e7af
     status: 200 OK
     code: 200
     duration: ""
@@ -7119,19 +7878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "601"
+      - "624"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7141,7 +7900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17134064-6aa2-4c3b-900f-8743f3ff869a
+      - 6b2ee398-7758-4312-bd42-bfc2fd0b4a2e
     status: 200 OK
     code: 200
     duration: ""
@@ -7152,19 +7911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:15.784704Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:21.022380Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "690"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7174,7 +7933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93d1a95b-9ae4-4cac-9e76-ae4690659517
+      - 914d341a-deea-40ac-9402-7f37cc212016
     status: 200 OK
     code: 200
     duration: ""
@@ -7185,19 +7944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282098Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863350Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "607"
+      - "630"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:31 GMT
+      - Fri, 10 Nov 2023 13:29:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7207,7 +7966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d85ce3d-0e4d-42dc-8783-5e38e52e387d
+      - 443a7b88-16dc-4158-9265-e30043f62bba
     status: 200 OK
     code: 200
     duration: ""
@@ -7218,19 +7977,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:32 GMT
+      - Fri, 10 Nov 2023 13:29:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7240,7 +7999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f1e9209-2f22-4973-b502-6cf764173329
+      - 9c6fa5cc-00b3-4b04-a351-66e28521618c
     status: 200 OK
     code: 200
     duration: ""
@@ -7251,19 +8010,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:37 GMT
+      - Fri, 10 Nov 2023 13:29:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7273,7 +8032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4da368f-eba8-4aa2-842d-409ac53c095e
+      - c2b2be61-4200-4da4-bf2a-c72de51d8c73
     status: 200 OK
     code: 200
     duration: ""
@@ -7284,19 +8043,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:42 GMT
+      - Fri, 10 Nov 2023 13:29:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7306,7 +8065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6aff95d-70f4-4983-b1cf-65efae1b813a
+      - f03033c7-4b51-4c6a-886b-7ba4492498ae
     status: 200 OK
     code: 200
     duration: ""
@@ -7317,19 +8076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "604"
+      - "627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:47 GMT
+      - Fri, 10 Nov 2023 13:29:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7339,7 +8098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99caef14-9459-4747-b1e9-64838ba00071
+      - 48c1c259-803a-40d4-94b2-7a46a935aa64
     status: 200 OK
     code: 200
     duration: ""
@@ -7350,10 +8109,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0fe117a-b3f8-45c0-9d73-9aa6942d1d6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:29:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f92ec48-4ff2-457b-8706-8a5021ceca3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:30:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a04d51fb-8054-41b9-b60a-e294340f49a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"76471576-5453-45a5-b5fe-64739c76a783","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -7362,7 +8220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:52 GMT
+      - Fri, 10 Nov 2023 13:30:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7372,7 +8230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1200c82f-21d4-4aec-aed2-7a6aa1552a33
+      - ae43d4ad-5185-4ab9-85cf-e6ec8cb66dc1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7383,19 +8241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:00:52.259085594Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544878786Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1455"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:52 GMT
+      - Fri, 10 Nov 2023 13:30:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7405,7 +8263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 880c3c58-27cc-407c-8287-12cc73f93371
+      - 14d5418f-d3f8-460d-80fc-80b40d3b063c
     status: 200 OK
     code: 200
     duration: ""
@@ -7416,19 +8274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:00:52.259086Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544879Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:52 GMT
+      - Fri, 10 Nov 2023 13:30:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7438,7 +8296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd00b7ce-afc9-4bba-8aee-4a3056b08b99
+      - 25fea5c3-eae6-4bf1-a316-dc86b274a009
     status: 200 OK
     code: 200
     duration: ""
@@ -7449,10 +8307,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1503e629-8dba-4e99-8960-e6f808f6c819","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544879Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1497"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:30:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e21621c4-5c68-4f0b-a08d-31af58885f64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7461,7 +8352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:57 GMT
+      - Fri, 10 Nov 2023 13:30:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7471,7 +8362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f11b26c-a447-47fa-b5a4-6bb1737a2870
+      - 29421981-2630-4820-99bc-a0f14c7015d0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7482,10 +8373,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -7494,7 +8385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:57 GMT
+      - Fri, 10 Nov 2023 13:30:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7504,7 +8395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 604c35f9-04c4-4de6-abba-b91a0548c7fa
+      - 907b4a3d-91f2-4c1c-9f9c-6129621c69ac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7515,19 +8406,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1503e629-8dba-4e99-8960-e6f808f6c819","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:00:57 GMT
+      - Fri, 10 Nov 2023 13:30:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7537,7 +8428,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e609325a-7943-4d96-9e90-aded8fc478a7
+      - d7039c38-afad-42e7-adda-dc1dfa850625
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:30:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 105db63d-34e6-4db7-a683-5c01e3c11be2
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"76471576-5453-45a5-b5fe-64739c76a783","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:30:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44e0bac7-93d6-48db-af6b-2d1bd2886204
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e20b14f-1c37-45fd-a910-c256192084c9
+      - 98edb633-899d-4019-a0a3-4622d759ac6e
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aeb15ba-d77f-415f-829e-bad7a3965f05
+      - 3160dd4f-ee9c-47af-859c-2e0715932eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "698"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8cca7a3-804e-4183-9927-017eb7fa589a
+      - 78d8e059-4ac0-4bd3-920f-a79a5709d18f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"1125c396-3316-458b-8e7f-867455a74b50"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686427Z","created_at":"2023-11-07T16:20:01.345686427Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353332977Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819188736Z","created_at":"2023-11-10T13:17:32.819188736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:32.887687873Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:17:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a9222e2-7674-45c2-b3f6-9d9d3a11efdb
+      - 438f95ce-e346-454d-a9c0-080fd7af9355
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353333Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:32.887688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:17:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1af82d2-5d8d-4295-b94b-151e56f208c7
+      - e49635e4-54ae-43bc-b4fe-6a092023c20e
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353333Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99b193af-b64d-4898-bffd-a79a92ef77f1
+      - 27840d45-5729-442e-acc4-da34a1b4a929
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:11 GMT
+      - Fri, 10 Nov 2023 13:17:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d464817-8438-4ec5-b5fa-57fc1a807864
+      - 7bb92e29-a3dd-473b-99bb-88eac3f22aff
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamVrNUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjZUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQzSm9Da1I2UzJOeUwxcHdjR00yWVVNeE9TODNNMWxDVWpCTWNFOUZVakJDV1dvd1RXVkNkMUpXWVU5VGIwcExRWGgzYWpoSk5IQm5ZV04xVkhKUVRHa3dVbVlLTUZObWMwRlhlbE5rWlU0ME5YbFJhMll4UkZjdmRTczBSa1pzT1RKWU5WRmlhV3hSUldOamVUSlpaV1Y2UlVOMVluQllMMWhzYURsUVJuaHhXR3h4U1FwSVUzUTVhMkV2TWxodldVVnNkMEpKUVd4NmF6aFFTalI1VHpnclRtUkdaemhWWW5sNVVtZGpNbXhtTXpodFZubzFURE5VTVhaVVExSm5ia0ZCSzBKdkNqWk9VbW92WVRrNWRraE1aek00YlhoT1dTOWFXalpGWWxrMGRHODNka3g2UTFCcVpuSm5SREZzVDBKM1dIWmFhVWt2YjJGbmRIVjFkeTlNU2xaelV6TUtUR1pKYmxORmF5dHZhVk5QYmlzNVVFbEphRkUzVERSQ1RrTXdkbk5aYTBkcVpXUk9iek5aV0c1ME1XZFNUR2R6VEdOcFFqUTJhV3RLWlZscVNWRkxad28xVVhnMU5EVTFhazU0T0ROUlExSjRXR2RWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCZG5VMFdqQmxUbUZXTmpKUEt6azRka1JYVVN0Mk5WUkpjalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDT0dObWJHaDBjak14U0ZFMVZVOW9NVEJoVWtSNFpETm5ORWw0TkRJeFYwRkxZMjFGWm1ST1VsaGlha0pOU0VSM1Z3cHdNR1JsYmpabmRHaDFUbTFNYVZVMU5tTnpUbUlyT1RkQ01FSnVlQzlRTlZVeU1UTlZTRVZLWVVsd05GbzJRakZ2ZHpOUlQyRm5VekpLTDBwTlFuTnNDbmxPTlRCU1FqSTJZMWR3YkRWUWNqQkxZWFJFUzNSRlYyOTRWbkEyTkZCUlMzQTNhMHR6TkdFeGJqVmhlVEF4Y0ZoTWMwSTRNM0pSUlVscmRrOXNVMWdLTVRoRFJEQk5WRU12YzBGaVozUktkRFl3UjIxbGIyUnROV0pFUlVKclJrRmhaVEV6TkhVeGRqVTJhVVpHTkhodVRqUlBNSEp5TlZsUVFqSlZlVWhtYVFwcGVFaHJiWGxZVURCTE5GZDRlVTFPYURoT1ZVYzBlVzF2WjFZNVN6bHpZMncyZFdoV0wybElWMHRvV0ZaemNEUm5kMWh2VjJkVmFWQldNMlZaYUU1SkNtaE5jMlYyT0cxck5WSm9Va0ZtVTJoTGFIQnZOV3RYVkZFNGJHeHZSa0ZOTWpRM013b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGI5YTE5YS1iY2VmLTRjZTAtODQ4OC0wZmU4OGI5MTkyMzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3eHlpYUpzWlNkVDllMnYxTWU5NVZ4S2pNQ2ZTWm9GdGNXS1FmU25kOHpRVVdoYWdacUM2cXpDYw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1454"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:11 GMT
+      - Fri, 10 Nov 2023 13:17:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6213269-2f63-4590-b78b-49febeae9330
+      - daee46c6-1ec5-4fd1-b492-a709dd166cd7
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwNXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlREUkZDbXc0U25KWFUxbHhXRVpCVmxkamNuTm9hbVpNUkdSWFJEZG9NbXBMZGtaeFdtVXpOU3RyV1hNeGNqZEdTR3hLVGxsclRHbFZWRmROYlZSVlYxbFNSVVFLZDJOb1oxQnlTakpEWmpCWWFIcFFWMVkyY0VST05tNVNXbkpsU0RkTWFsTTJSMWhxVWpCeU5rUTBXR2xUTjBSR05sTm9kemhPYm5sdGMyeGpVbUV3V0FwRWNHWm9aSFJMZERGWFIzZE9kRUYwZFhOeGVWZGhSR0owVG5WeWFsRnVlbXh5VDFCellVRmFSRGRSVXpabmJtcHBkVXhKZWtGWFlscDFZV1pTUVZONkNsSllkamR4TTBsU2RrZGpSa3QyYkhVeGRGVXlkRkJ3V2tOMVJVbFpUekpPVVVVM1JYVkVaRWRTYzA5dWIxaE9WRGRRUm5JMWVXTXZTMnBxTldRNU1Ea0tWSGgyY0hjeFpXRjVORlZKZEhOSGVVaHVhMFV3VmxKMWRsZHpXbmt6T0VsaE5VRktWbE16TDFoblNsZENhR3hKU2tkc0sweG5aV3RFUWtSSldrTmlWd3BOV20xbVNIbFFlbmxYYlVWdlZISnJTRWxOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWkRCSmVYRkZSVGRYTWtoT1pVNXFiV050YURScWFIWlFNV1JOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVG05R1JGRjVha3hsWmxGdFFtUlZaVmd6WTNWNWEyNTJaMEZuTlRaSU5XOTNWa0p0VlRORVprMHhlbUZrWXpkMVZRcDZlazFYVWxKRVEzWTRhbTlqYWtSWWNVMWlTREZtVG5ocVUyb3dabkl6Y0dSSGJUSlVabXc1VFdVeWFtSk1hMVJyZFVoWlNtOXpUR1YxTHpGdlZuUlBDa2RPYlhaNmMxWlhTR3R3Ym5wamMybFZiekJQTVZwTGJWQldkMFZNU2prMVptTnRRMjVSUkVObFNUbElZVmc0VVZONE5VWnhWakowU210bU15dHpZMDRLUlhkcVZUZHFTalF2U2xkelZFdzBZbEJyUldNeU4zbFVVSGt3UWpSRlJVNW1VekZ1TVVadWJXeE9UbE5zWkhGWVdVUlpkWGhXV0M5UE15OTFWelpoY0FwNE9ETXpSak41ZFRGb0sycGlVRGRJZWs5MFkycE9Mekp5TUdwR2Jtc3plV05UV1V4M2RESk5hR1kyVDJONGFHbEhZVmMxVFN0dWNsazRUV1pUVURkSkNreEZOMkV4YlZGMGFITklSWFkwV1RKNWFYTlplazVvVFRCS1UzRm9NMk41WVhaSmN3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81YmI5ZjA0Zi0wM2YzLTQyMGYtYjFiZi05ZTYxMGVkMmNhZDIuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLaEZaVnpsdE5pNUF6Vk9DM05wa3JkSFQwYklmMUFacU80d0lKSXNMMGpCN2U4ZEhZRGJZRms3Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2604"
+      - "1499"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:11 GMT
+      - Fri, 10 Nov 2023 13:17:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,40 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da7c4f64-70d8-4d40-bbd7-34f6c62afe04
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1454"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:20:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a65e1f32-f760-4c10-b2a7-a71591af2c03
+      - 389bf314-f6cc-434e-9109-ed732a78a49a
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786036Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764551973Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "650"
+      - "675"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:12 GMT
+      - Fri, 10 Nov 2023 13:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceedb538-0f1f-4488-a375-6d90bc035b88
+      - ed2ee012-e159-4950-9d41-61b087753289
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:12 GMT
+      - Fri, 10 Nov 2023 13:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f300452e-7271-426c-88db-ebc6fcbcc657
+      - fb9d8622-bc22-4349-8f98-3eef2cc85f7f
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:18 GMT
+      - Fri, 10 Nov 2023 13:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa2d02c0-a7cc-4150-8be3-fd95b42bd3d7
+      - 9a90c89e-a05b-49d0-9295-5bc348564f0e
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:23 GMT
+      - Fri, 10 Nov 2023 13:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b08ff008-1577-411c-bf23-cee0988dab8a
+      - a05e6f83-ebf3-463b-97cb-c36dfaa3f08b
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:28 GMT
+      - Fri, 10 Nov 2023 13:17:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94727d5b-a80b-4e24-9a4b-fd7e8cce4cf9
+      - e3c0d9fc-61c9-44c1-b923-97407866b4b6
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:33 GMT
+      - Fri, 10 Nov 2023 13:17:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3db52863-aade-46d4-b323-ad9fc21581dd
+      - 024c9ccf-598f-4f47-b0bd-ad29e2689926
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:38 GMT
+      - Fri, 10 Nov 2023 13:18:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa325f5e-f2c2-4710-9dcc-d3bc69e3ff43
+      - 98bd0092-9067-45f5-bbda-1e3e4c1052ae
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:43 GMT
+      - Fri, 10 Nov 2023 13:18:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfb75035-25e0-489e-8832-bb513d5009c3
+      - 3691cb9f-1d74-476e-8941-8d0b00574064
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:48 GMT
+      - Fri, 10 Nov 2023 13:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 750dcafb-1b74-427d-9229-efbac3152c59
+      - 94cb17ae-5b53-4018-839a-00f7af6fb1ac
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:53 GMT
+      - Fri, 10 Nov 2023 13:18:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52f4c93e-2fac-407c-b845-38f6152d2e6a
+      - 94361453-fb2f-4242-bd32-556143183c34
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:58 GMT
+      - Fri, 10 Nov 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39deaa60-d4cc-420f-9f7b-9dbb4c303ac6
+      - 0fee5239-348e-42d7-8b27-3fee96be468b
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:03 GMT
+      - Fri, 10 Nov 2023 13:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 657d691b-a2ca-457b-92b6-532de16fbfdd
+      - 74a2570d-fafa-478d-a6c2-b0a4ecd79609
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:08 GMT
+      - Fri, 10 Nov 2023 13:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a6a6eb-1be2-4a65-9cf3-7cf13d6712d7
+      - 9eaf2f13-656d-4cca-a0f4-02ca527fc989
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:13 GMT
+      - Fri, 10 Nov 2023 13:18:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8a3c2d-4e37-4423-ac7c-f9bb7d6050b1
+      - 2d40c9ac-9e4d-4101-bb1d-1c1cb32edfc9
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:18 GMT
+      - Fri, 10 Nov 2023 13:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 798a7491-f2bc-460c-995a-7cec9f444862
+      - 57734298-1f19-4d47-bc67-605bfedcc6e1
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:24 GMT
+      - Fri, 10 Nov 2023 13:18:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6db5992-7a97-4eb3-8e53-699dcd8e134a
+      - 524c0be6-2f51-4dbf-8593-c3da4145aaef
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:29 GMT
+      - Fri, 10 Nov 2023 13:18:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc4a22c1-0e47-4c96-89da-e33fc7eac9c8
+      - d4d2d80f-e7f0-495a-a263-184f001e47c7
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:34 GMT
+      - Fri, 10 Nov 2023 13:19:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f03b2b0b-c4f5-4d86-93bf-69c9f66355a3
+      - e45e7f34-3922-413a-96b4-c4c97e33905c
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:39 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c121d34-b5fc-4f7b-8bcd-2a6c68f4b159
+      - 81694911-aaf6-4ac3-a72b-377405868e95
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:44 GMT
+      - Fri, 10 Nov 2023 13:19:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2537ec1b-6793-4a7e-826c-c030e467e20c
+      - 1b03116b-01a8-45a5-9948-273a69c0800a
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:49 GMT
+      - Fri, 10 Nov 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6260f90e-128a-4819-bc48-2c8e391d7d3a
+      - fe5496ad-b44c-4f58-9133-3ba188bad785
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:54 GMT
+      - Fri, 10 Nov 2023 13:19:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89238866-8679-456e-a09b-bfbbed41a7a5
+      - 230d8b03-a9fb-49eb-ba97-dc5b409dce38
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:59 GMT
+      - Fri, 10 Nov 2023 13:19:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 174d0218-cea8-49ef-b140-3e23d0230fc7
+      - 69b1da85-4fcd-42cb-865e-ea3e778cad3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:04 GMT
+      - Fri, 10 Nov 2023 13:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1800f2be-6eb9-4769-b05a-23c5c6fe1162
+      - 0c86c1fc-3e9b-488b-b05f-441b70d89a8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:09 GMT
+      - Fri, 10 Nov 2023 13:19:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28ca7605-f265-48cf-a071-97a901e31a09
+      - 3653d40c-3f92-47f7-9853-4e07acfa3f3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:14 GMT
+      - Fri, 10 Nov 2023 13:19:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c14bba9c-0261-4c28-96d6-c9cce99013d0
+      - 80640b59-75ef-4c96-a4cf-19909ff30c58
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:19 GMT
+      - Fri, 10 Nov 2023 13:19:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d6f46f5-d7a1-44e6-b01d-205222fec033
+      - dffc6d04-75f1-449a-90f5-db3240de4d46
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:24 GMT
+      - Fri, 10 Nov 2023 13:19:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c431b116-0e00-41ed-a9dc-a79e2d5908f9
+      - 026b01ae-4651-429b-bbe5-fda234dc376a
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:29 GMT
+      - Fri, 10 Nov 2023 13:19:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aa3f1a0-9374-45c9-a4e0-30a202e583af
+      - 0a45a9e3-e8d7-45cb-b69f-d623e11c04fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:35 GMT
+      - Fri, 10 Nov 2023 13:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb676acd-43ec-407d-86da-3d92c1537fef
+      - e9f2fbb9-6167-4e31-8d91-30786dddfccd
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:40 GMT
+      - Fri, 10 Nov 2023 13:20:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa4f0f72-9ff4-4c0e-95aa-62273bd6480d
+      - 0746d745-d1f6-45e7-972a-8bd77c527fe7
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:45 GMT
+      - Fri, 10 Nov 2023 13:20:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33a3c690-ad57-43ed-a400-765aa41ac52f
+      - e17a4f72-616e-49e9-bd5b-6de89bed03b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:50 GMT
+      - Fri, 10 Nov 2023 13:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f87c4a7-0669-4b7c-9f38-8a04a89d476e
+      - dcc97bf3-38a6-45eb-93d0-fdbc429f7ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:55 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18858ac5-2c23-4052-9608-b17bbdba8853
+      - 19ddd2ba-f7a4-40c5-8c30-cda3f7dd85f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:00 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba4b605-393f-47d0-8b85-827a0e26e16b
+      - 6c6b6e29-b1d0-40a5-9005-32a28a2a6c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:05 GMT
+      - Fri, 10 Nov 2023 13:20:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65176a95-c46d-4ff2-a866-eda7ad7d5283
+      - f606af2b-7781-45d7-a3b3-83c2269c42fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:10 GMT
+      - Fri, 10 Nov 2023 13:20:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a406ced-cbe4-4648-808a-217b50dc81d1
+      - 11c6bb40-4020-4be3-9e18-397ad954cbca
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:15 GMT
+      - Fri, 10 Nov 2023 13:20:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5aa18b4-fb32-4a17-a023-dddcedd6e745
+      - 20ea6eb9-37d5-4b96-835b-3521a6fe2fb9
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:20 GMT
+      - Fri, 10 Nov 2023 13:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a23182c3-0de5-4310-af74-2be2f0cf14b2
+      - c8b5fab0-d299-46ae-8189-c2a0a6aa3533
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:25 GMT
+      - Fri, 10 Nov 2023 13:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde8d687-0d54-4d4a-b49e-da745739bc0d
+      - 3a076a70-d4a8-4595-a36c-fff3d60182e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:30 GMT
+      - Fri, 10 Nov 2023 13:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0be9c65-07fe-447a-8264-adf90f5f0964
+      - f1ade5d8-3de3-4366-9eeb-e75ffc5b0c9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:35 GMT
+      - Fri, 10 Nov 2023 13:21:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16982710-40a7-4141-a1d9-a99626bf06b6
+      - 9682d787-a390-4d40-818b-f9b34f0f7202
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:40 GMT
+      - Fri, 10 Nov 2023 13:21:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 088106cb-d40e-4a45-9815-43326a695802
+      - 9dcb0032-ce6b-4c86-ad2a-051b09ee5467
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:45 GMT
+      - Fri, 10 Nov 2023 13:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c179d5ea-c6f3-4037-979a-fc32e1ce156b
+      - 350c697a-c4a4-4fcd-808b-61baffcbf85d
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:50 GMT
+      - Fri, 10 Nov 2023 13:21:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da1faff7-adff-4f82-93e2-c2e2310e89f0
+      - dde0fea1-89bc-46d2-afa7-f34133928b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:55 GMT
+      - Fri, 10 Nov 2023 13:21:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 177a07d1-e59b-4e20-93eb-a31f7312a945
+      - a14cba84-5a7e-4273-bc84-90d81071b047
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:00 GMT
+      - Fri, 10 Nov 2023 13:21:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aea3d9b-71d8-45af-b1d6-5c2d85fbaf6d
+      - 0912a3c9-6b0a-4a4f-aeda-961aab1f67cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:21:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7a5b09c-269f-4b4d-903e-67a17a5e8a98
+      - 1b3e78f1-a5fe-4b51-b601-2c04a5a2d23a
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:11 GMT
+      - Fri, 10 Nov 2023 13:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f09bb5ce-37b6-4052-bdcb-da8826b449cd
+      - 8a180d4c-f6c1-4ee3-8487-2612a5704b91
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:16 GMT
+      - Fri, 10 Nov 2023 13:21:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - addd2b9b-d62a-4b02-9d00-cbe56d7db166
+      - 165d0eab-2ff7-474b-a668-f9de1296ea6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:21:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cb7dbf7-a273-4314-ac8e-31c86274a8e0
+      - 3f2f4067-834a-4102-a652-62508f80d438
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:21:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7259b285-e0fc-4cf0-871d-8688bdf14767
+      - 59cbfd31-9d38-454d-a281-524472c6d7c8
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:21:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13433931-9fc5-4c4a-b905-65884edd8cdf
+      - 76f4a2fe-35dd-4d33-a246-884c53cf8460
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:36 GMT
+      - Fri, 10 Nov 2023 13:22:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 717d183f-7eec-474a-9411-db5b9606a6ae
+      - 427e2ef1-dd5d-4bf0-8d31-c1f1296c8719
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:41 GMT
+      - Fri, 10 Nov 2023 13:22:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15c97d01-787e-4a80-bff1-67aabffb4ee0
+      - 16f47843-933b-4789-b875-8c984b0e0244
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:46 GMT
+      - Fri, 10 Nov 2023 13:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0e772e4-a6f1-446b-a326-70bdc9853591
+      - 274c3bd5-86b5-48d0-82db-fc334dfc4dd1
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:51 GMT
+      - Fri, 10 Nov 2023 13:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8f88f48-9a65-4a2b-bd73-fadd878dec19
+      - 585f0118-11b3-4462-9806-159fffa9c015
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "647"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:56 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37449641-dae6-4194-8158-df71a74cbef4
+      - bd1e1ab6-f178-4dc7-af44-812b514562fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "647"
+      - "1491"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:01 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a57b546e-25e5-47ef-ab20-01f2bed5f78e
+      - ddfdd62d-7749-4761-b3a9-b5ceb244b54e
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "645"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e663226d-969e-42e4-ac15-518b6a9c3247
+      - a9b7da72-682b-46c7-b726-f2a54ba7e8d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/nodes?order_by=created_at_asc&page=1&pool_id=4c139d79-c993-4ce6-822d-b4284cd0d713&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:39.408229Z","error_message":null,"id":"2a1c9d37-4f9c-47da-98a7-71b7d87da8a1","name":"scw-test-pool-zone-test-pool-zone-2a1c9d374f9c","pool_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","provider_id":"scaleway://instance/fr-par-2/ecc31da0-0b67-4e03-8720-b2b3174087ea","public_ip_v4":"51.159.141.113","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:19.097246Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1446"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8445d9af-00a0-4331-9cfc-1d221ea8a6b6
+      - c40d7ca6-fee3-4c8b-99cd-1e4ef8d7ebe8
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "645"
+      - "1491"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165581a6-6dbc-418b-bf51-cc76506abd39
+      - 65ebbff6-baeb-4b32-b4da-cf36fd1eda02
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/nodes?order_by=created_at_asc&page=1&pool_id=a6e741b9-dc84-4f78-9956-fe8830e20325&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:16.028152Z","error_message":null,"id":"f6135907-3760-4c49-8cd7-c5b95609d3ea","name":"scw-test-pool-zone-test-pool-zone-f61359073760","pool_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","provider_id":"scaleway://instance/fr-par-2/f5fb3bc1-574d-4299-9b0f-0415ca26f7a9","public_ip_v4":"51.159.162.93","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:25:02.312448Z"}],"total_count":1}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "641"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 290d8b40-b2b0-47fb-a7a2-5716a9b1fbf8
+      - 8115958a-5d05-41f8-a197-eb2159d3ac7d
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1446"
+      - "714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed26f259-f470-4228-8325-3b9018110bf7
+      - 87eb2bb7-9b7e-444a-815f-fc290a002558
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "645"
+      - "1491"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7911e2a-8a41-4604-b600-b8c7604bb209
+      - 7e78daf4-35b4-4948-98c1-2314c6273c12
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamVrNUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjZUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQzSm9Da1I2UzJOeUwxcHdjR00yWVVNeE9TODNNMWxDVWpCTWNFOUZVakJDV1dvd1RXVkNkMUpXWVU5VGIwcExRWGgzYWpoSk5IQm5ZV04xVkhKUVRHa3dVbVlLTUZObWMwRlhlbE5rWlU0ME5YbFJhMll4UkZjdmRTczBSa1pzT1RKWU5WRmlhV3hSUldOamVUSlpaV1Y2UlVOMVluQllMMWhzYURsUVJuaHhXR3h4U1FwSVUzUTVhMkV2TWxodldVVnNkMEpKUVd4NmF6aFFTalI1VHpnclRtUkdaemhWWW5sNVVtZGpNbXhtTXpodFZubzFURE5VTVhaVVExSm5ia0ZCSzBKdkNqWk9VbW92WVRrNWRraE1aek00YlhoT1dTOWFXalpGWWxrMGRHODNka3g2UTFCcVpuSm5SREZzVDBKM1dIWmFhVWt2YjJGbmRIVjFkeTlNU2xaelV6TUtUR1pKYmxORmF5dHZhVk5QYmlzNVVFbEphRkUzVERSQ1RrTXdkbk5aYTBkcVpXUk9iek5aV0c1ME1XZFNUR2R6VEdOcFFqUTJhV3RLWlZscVNWRkxad28xVVhnMU5EVTFhazU0T0ROUlExSjRXR2RWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCZG5VMFdqQmxUbUZXTmpKUEt6azRka1JYVVN0Mk5WUkpjalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDT0dObWJHaDBjak14U0ZFMVZVOW9NVEJoVWtSNFpETm5ORWw0TkRJeFYwRkxZMjFGWm1ST1VsaGlha0pOU0VSM1Z3cHdNR1JsYmpabmRHaDFUbTFNYVZVMU5tTnpUbUlyT1RkQ01FSnVlQzlRTlZVeU1UTlZTRVZLWVVsd05GbzJRakZ2ZHpOUlQyRm5VekpLTDBwTlFuTnNDbmxPTlRCU1FqSTJZMWR3YkRWUWNqQkxZWFJFUzNSRlYyOTRWbkEyTkZCUlMzQTNhMHR6TkdFeGJqVmhlVEF4Y0ZoTWMwSTRNM0pSUlVscmRrOXNVMWdLTVRoRFJEQk5WRU12YzBGaVozUktkRFl3UjIxbGIyUnROV0pFUlVKclJrRmhaVEV6TkhVeGRqVTJhVVpHTkhodVRqUlBNSEp5TlZsUVFqSlZlVWhtYVFwcGVFaHJiWGxZVURCTE5GZDRlVTFPYURoT1ZVYzBlVzF2WjFZNVN6bHpZMncyZFdoV0wybElWMHRvV0ZaemNEUm5kMWh2VjJkVmFWQldNMlZaYUU1SkNtaE5jMlYyT0cxck5WSm9Va0ZtVTJoTGFIQnZOV3RYVkZFNGJHeHZSa0ZOTWpRM013b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGI5YTE5YS1iY2VmLTRjZTAtODQ4OC0wZmU4OGI5MTkyMzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3eHlpYUpzWlNkVDllMnYxTWU5NVZ4S2pNQ2ZTWm9GdGNXS1FmU25kOHpRVVdoYWdacUM2cXpDYw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "698"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38ac7115-465c-46cc-b588-01afddb4d7e8
+      - ca482b86-44db-49b7-8593-2f8457a47546
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "1446"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5fee3a0-20e5-41f5-ac4b-0a8a057bfde7
+      - 3bc0968b-e979-4378-8b97-40899862ba0a
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/nodes?order_by=created_at_asc&page=1&pool_id=4c139d79-c993-4ce6-822d-b4284cd0d713&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwNXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlREUkZDbXc0U25KWFUxbHhXRVpCVmxkamNuTm9hbVpNUkdSWFJEZG9NbXBMZGtaeFdtVXpOU3RyV1hNeGNqZEdTR3hLVGxsclRHbFZWRmROYlZSVlYxbFNSVVFLZDJOb1oxQnlTakpEWmpCWWFIcFFWMVkyY0VST05tNVNXbkpsU0RkTWFsTTJSMWhxVWpCeU5rUTBXR2xUTjBSR05sTm9kemhPYm5sdGMyeGpVbUV3V0FwRWNHWm9aSFJMZERGWFIzZE9kRUYwZFhOeGVWZGhSR0owVG5WeWFsRnVlbXh5VDFCellVRmFSRGRSVXpabmJtcHBkVXhKZWtGWFlscDFZV1pTUVZONkNsSllkamR4TTBsU2RrZGpSa3QyYkhVeGRGVXlkRkJ3V2tOMVJVbFpUekpPVVVVM1JYVkVaRWRTYzA5dWIxaE9WRGRRUm5JMWVXTXZTMnBxTldRNU1Ea0tWSGgyY0hjeFpXRjVORlZKZEhOSGVVaHVhMFV3VmxKMWRsZHpXbmt6T0VsaE5VRktWbE16TDFoblNsZENhR3hKU2tkc0sweG5aV3RFUWtSSldrTmlWd3BOV20xbVNIbFFlbmxYYlVWdlZISnJTRWxOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWkRCSmVYRkZSVGRYTWtoT1pVNXFiV050YURScWFIWlFNV1JOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVG05R1JGRjVha3hsWmxGdFFtUlZaVmd6WTNWNWEyNTJaMEZuTlRaSU5XOTNWa0p0VlRORVprMHhlbUZrWXpkMVZRcDZlazFYVWxKRVEzWTRhbTlqYWtSWWNVMWlTREZtVG5ocVUyb3dabkl6Y0dSSGJUSlVabXc1VFdVeWFtSk1hMVJyZFVoWlNtOXpUR1YxTHpGdlZuUlBDa2RPYlhaNmMxWlhTR3R3Ym5wamMybFZiekJQTVZwTGJWQldkMFZNU2prMVptTnRRMjVSUkVObFNUbElZVmc0VVZONE5VWnhWakowU210bU15dHpZMDRLUlhkcVZUZHFTalF2U2xkelZFdzBZbEJyUldNeU4zbFVVSGt3UWpSRlJVNW1VekZ1TVVadWJXeE9UbE5zWkhGWVdVUlpkWGhXV0M5UE15OTFWelpoY0FwNE9ETXpSak41ZFRGb0sycGlVRGRJZWs5MFkycE9Mekp5TUdwR2Jtc3plV05UV1V4M2RESk5hR1kyVDJONGFHbEhZVmMxVFN0dWNsazRUV1pUVURkSkNreEZOMkV4YlZGMGFITklSWFkwV1RKNWFYTlplazVvVFRCS1UzRm9NMk41WVhaSmN3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81YmI5ZjA0Zi0wM2YzLTQyMGYtYjFiZi05ZTYxMGVkMmNhZDIuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLaEZaVnpsdE5pNUF6Vk9DM05wa3JkSFQwYklmMUFacU80d0lKSXNMMGpCN2U4ZEhZRGJZRms3Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"nodes":[{"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:39.408229Z","error_message":null,"id":"2a1c9d37-4f9c-47da-98a7-71b7d87da8a1","name":"scw-test-pool-zone-test-pool-zone-2a1c9d374f9c","pool_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","provider_id":"scaleway://instance/fr-par-2/ecc31da0-0b67-4e03-8720-b2b3174087ea","public_ip_v4":"51.159.141.113","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:19.097246Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2604"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
+      - Fri, 10 Nov 2023 13:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c039d9c-72f2-4157-bf5e-d47f6d6910d6
+      - 0d613fc7-e77e-4a08-bde3-c81504615bf4
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,85 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "645"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e705f85a-99bf-4a93-929c-298d428201cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/nodes?order_by=created_at_asc&page=1&pool_id=a6e741b9-dc84-4f78-9956-fe8830e20325&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:16.028152Z","error_message":null,"id":"f6135907-3760-4c49-8cd7-c5b95609d3ea","name":"scw-test-pool-zone-test-pool-zone-f61359073760","pool_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","provider_id":"scaleway://instance/fr-par-2/f5fb3bc1-574d-4299-9b0f-0415ca26f7a9","public_ip_v4":"51.159.162.93","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:25:02.312448Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:25:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15a1b3b9-9d45-4aad-a87e-cdae1bb18946
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797094991Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "651"
+      - "676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:08 GMT
+      - Fri, 10 Nov 2023 13:22:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04009b74-2767-4952-b667-bbb0a00d3193
+      - 02b6a4e2-cbd0-4d40-a7aa-94a50935042b
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:08 GMT
+      - Fri, 10 Nov 2023 13:22:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dee69ff-15f7-4e0d-93ba-0a3087754f3b
+      - e3f47e45-2378-4399-93dc-78447a5ad13b
     status: 200 OK
     code: 200
     duration: ""
@@ -2724,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "648"
+      - "673"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:13 GMT
+      - Fri, 10 Nov 2023 13:22:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38ef0a09-b397-4784-8dae-48caee5d4531
+      - 02cbbcbe-69b8-4fe3-bf60-3e38e72e8b4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2757,10 +2658,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ef62daf1-c4b7-4a21-9ebc-9914c8b692ce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 730ddc3d-3ab5-4e5b-a749-d422b080f7a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2769,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:19 GMT
+      - Fri, 10 Nov 2023 13:22:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65c5f012-397d-4cd6-8f62-fba2b296d130
+      - b487edd6-11b7-45b1-8ef4-6c1e62ae9aac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2790,19 +2757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942353Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519174759Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1497"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:19 GMT
+      - Fri, 10 Nov 2023 13:22:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85423279-3455-4ecb-9374-179ae48bcd07
+      - 75395010-3ed3-4395-9f36-6718a9a53678
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,19 +2790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:19 GMT
+      - Fri, 10 Nov 2023 13:22:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5044e146-fadc-44e2-865d-27675fcf0b3c
+      - 11c5f21e-62c9-4108-89e9-143e2568c24f
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,19 +2823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:24 GMT
+      - Fri, 10 Nov 2023 13:22:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2878,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff6796a6-8a8c-490b-a0fc-c28859e652cf
+      - ac0b00d7-bd2d-40f6-a358-62a43f228c15
     status: 200 OK
     code: 200
     duration: ""
@@ -2889,10 +2856,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1494"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 714643b1-ea81-46df-96e2-d25b027d76db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2901,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:29 GMT
+      - Fri, 10 Nov 2023 13:22:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e996622-8f58-4786-90b5-b9e0c4ae7202
+      - 9d87f05a-77c4-4842-b8e5-3e180ab2836e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2922,10 +2922,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"1125c396-3316-458b-8e7f-867455a74b50","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2934,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:29 GMT
+      - Fri, 10 Nov 2023 13:22:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b952e66e-cd62-4cb3-8e9f-3d1045432a9d
+      - 56785a80-c38a-498f-b26c-362764993910
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2955,19 +2955,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:29 GMT
+      - Fri, 10 Nov 2023 13:22:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +2977,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00001876-4efe-455c-9fae-193f8ce81ee3
+      - d411e1fa-aa3d-41bc-abb0-1a27e09e2ad9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 360cb8ce-ca31-4ff1-9132-bf4c80dc7d1a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:22:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 78401aa4-0868-4499-b095-f1e1d990c853
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60646dae-e4ab-410d-9424-ce80c401f045
+      - 780a9655-6cb8-4920-8019-b0ca95a94a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62d6d03a-5b3f-4132-9a28-b341830e1aab
+      - 81c5d770-f5dd-4bd3-9375-eec2dab663dc
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c26fc414-f1e4-41ec-96ad-bad3f81b5ed4
+      - 883fdee5-0579-4d21-a88d-dd7c809b05df
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202959621Z","created_at":"2023-11-07T16:20:01.202959621Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.214928607Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529941827Z","created_at":"2023-11-10T13:16:58.529941827Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.540395017Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9e93287-3108-4e1a-a0f6-f99fb1fcdce2
+      - 3cce046b-1f5b-419d-a98c-6d93356081a9
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.214929Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.540395Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:01 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 274f4261-1d6d-4b83-8b81-1198e68ee568
+      - 1599ea4e-0bba-4610-8746-d360387ea35f
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e88596f-2675-4bde-8778-e1861a4b02a3
+      - b331818c-607a-42ee-a677-5ba9ccad9e58
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6276f075-74de-40bb-8c45-1d13635f02a8
+      - 596e9f88-ba1d-45f2-9c6b-c95fe61752d0
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1aebb882-50f2-4cf2-8ea7-c129ed2c3cad
+      - 8e5777fd-7c52-4b92-9ddc-6a29e8e8a924
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9812ac02-7fd8-45d4-8f6f-79fc84694273
+      - eaf6fc58-2758-451c-9c57-8534aeec09e5
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18884fa8-b201-49b5-8a1f-47f076bbabc7
+      - 14eff6ac-657c-4950-989f-d424fd73b2ae
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4828126-b42e-4074-9282-248a2340e8ca
+      - 64a36b8b-03b6-41ba-b79c-f5cb4f388036
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ad6e754-dff2-4d45-b367-4f57c1199f90
+      - b0c8a90c-471c-4d98-81b6-41391136db58
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebd3313f-cf61-4e15-8fb9-8decfa2325e1
+      - 74eb5508-5a98-46fb-a3a5-a52f6c80a95a
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2440a27e-87d7-45e2-bd51-c4195546bcf0
+      - e5f8d0eb-e5cf-475d-a241-199aa443700f
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 815506f0-c39f-499e-ac87-af8c109c4765
+      - de8771bb-b480-4f20-b100-59c0ebcbfbaa
     status: 200 OK
     code: 200
     duration: ""
@@ -511,19 +511,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00d8586e-b16e-40ba-8a34-62ee2f0cdad0
+      - e1455d96-8331-44c5-8b3f-ec6f5fe74689
     status: 200 OK
     code: 200
     duration: ""
@@ -544,19 +544,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be9836d7-8f50-4152-b92f-6438921cd88e
+      - 1fc5b8fa-c80c-493f-bb11-023c75cca2ab
     status: 200 OK
     code: 200
     duration: ""
@@ -577,19 +577,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.641478961Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.178237886Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39752d40-2fdf-4f02-b75c-1239bb97b2a1
+      - 334eb357-caf7-4325-9513-8c4bacc86539
     status: 200 OK
     code: 200
     duration: ""
@@ -610,19 +610,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.641479Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.178238Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8d8fa2-68f1-4e40-bc90-99971134879b
+      - bb0c69b4-e125-446e-b860-5e762e83f061
     status: 200 OK
     code: 200
     duration: ""
@@ -643,10 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -655,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:13 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -665,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d9e700d-0844-4cda-ab17-c767996bd35b
+      - 94cb9e1b-9e33-4206-beda-22692384a083
     status: 404 Not Found
     code: 404
     duration: ""
@@ -681,16 +681,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:17:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a031bb3e-ac29-4723-8b34-bcf470d22b90
+      - e4fc6c4a-daa1-42a7-80c0-d555f9853de5
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:15 GMT
+      - Fri, 10 Nov 2023 13:17:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,12 +733,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa166378-366b-4040-bd04-9190f168b3e3
+      - 7aa0bf4d-a088-4f47-908c-f4bd8c0fb886
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999"}'
     form: {}
     headers:
       Content-Type:
@@ -749,16 +749,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921622925Z","created_at":"2023-11-07T16:20:15.921622925Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.003047962Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302129Z","created_at":"2023-11-10T13:17:13.891302129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.092792908Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:17:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a17fad14-da54-48a4-a6ad-d38b38ecf206
+      - ebf08ca9-e1f6-4b61-b064-50472d65b00b
     status: 200 OK
     code: 200
     duration: ""
@@ -779,19 +779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.003048Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.092793Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:16 GMT
+      - Fri, 10 Nov 2023 13:17:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 594dc933-9371-4bdf-b55c-49f73f2ec2e5
+      - 5d27e271-b273-417d-a092-3d1a09e05b04
     status: 200 OK
     code: 200
     duration: ""
@@ -812,19 +812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:21 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f1b1cd4-2a20-41d2-aad5-5233c2bf2319
+      - c13b3f72-976e-4bde-89f3-153a39af9277
     status: 200 OK
     code: 200
     duration: ""
@@ -845,19 +845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:21 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 828350b2-d422-47a8-993a-abd871369f27
+      - 573f4013-1d61-4ce9-b20b-5ead93672764
     status: 200 OK
     code: 200
     duration: ""
@@ -878,19 +878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJlRTlHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0Y0VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWG80Q2s1R1kwOUVWRXh6UVM4dkwzbEtWa3hvVERoc2JtazJlRlJLY1cxRWNrMXVPR1kwUTIxWWFXSm5NRzgxWmtkalJHRkpiMEUwVGswMFUwWkVaR05EU0U4S2RUZENVRlJvZG5Od2FFVnBVbUl4WXpCMGVHcGlUVFJIUzA1d1lVRmxkVVJpYm14SmMwZDFNSFZwUVd0a2EzVTRiM1JvVTJZdlMzbHNkU3N6Y2xwWlRncHFiazVYYkVSbVMyNVNieXRZYVVGdk5XOURVMDVDTkdOdFMxcE1aMFF4YjI5Q1JXWTFaMHhHVmk5cWNGSjFiV0ZQVWpSSGRuazRMMlF4VWtGMk1qWlJDakpJVjNoNlZuTnpkRWg1TVZWRlEyRXllakpHWVVZcldYbzVhVmRXUm0xcVQyVnlTMU5tZDFsMlYyMVJZa2RIYzA1aUwzWkxkVzlhYzJsbFlVZDVVMndLZHpWS00wbHFVRkV5UkM5MVZsWnJibEZXVVd3M1lUUmFNMDE1ZURoSFFYb3JWblE0V0UwNWRuRnpNWEJxT0RCTVdGWkxUa1JPYzFrM2FFVlhjWGRWWmdwalR6ZFRiRXBuVW5GRU9HMTROSE16TWtSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVptcFRWMGxJTUcxWVRGQTBlVEZKU201RlJEVXZMMkZ4WTJoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJERlpUbWw1ZVd3ek5UQklSR2xqV0V0TWFrY3pWVmhyTlZweVJHTTFhRUpDVGpnM00xWXlOV2t3WTNFek5teDRTZ28yUldwQkwweEpWWGc1V0Uxb1JVVmhXV05DZUhKMU1FOVRlbkpqTlRCdFdWRjBlWEpCUm1wcVMxQlViVmhPYkhFNVEySkxVMGRpVEhFeGRsWkxPR0pNQ214VFZWbHZiVTlIWkdkc2FqVnRORFJUZFZOcGJtVmFRV1Z2Tmt0ekswSlVhVTk0ZGs1M1ZrbzJWVEUwT1ZSaU5GUlFabVE0VFhRMU1XZ3JRME5ZUWxZS1VYVlBUSGxHTUZOc1RsQkhLM013WmpoMWNVTjJVWFJHV2psbFpFNVZaSEZtVW5aSVoxTk9hbE5SZWk5b1p6TXZaV2RDYjNoTFZUQnpPWGRuV1hkTU1ncDNTRVJYYW1STFZUTmhkbFk0WnpnelZXeDBSVFpPUzFCVWQySndZbTVHVTJscWQxVXhaRWhJTmtWck5IVm9SV1ZFT1RaWmQzUmhRMjA1YlRWM1JrNUtDbE5zUW1Sd2IwaEVkVTV1TDJRcmFXOVNWSEZsVUhadGJ6VmFNM1E0YzJ4WmIzaHFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzYzZmU0MDQtMzZjNy00YzkyLWEzY2EtZGFlZDVkMjE4YzYzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0clN1RDJhRjF1NEZic2M1WWtLdlhwS0lKbVJhSDg4WHZidXlCVUV6WHZ5bng5RjBCVmRFS0h3ZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplRTR4YjFoRVZFMTZUVlJGZDA5VVJYcE5WR040VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWEkxQ2preGJVUldiSE5TUjFkQkwwOUhkemwxT0ZaTVptcERhekpTV1ZBNFNVOWFObWx1YUhRMVFUZGhaWEpsWm10VlZTdDNjbnBTUTBsNk1VUlRjRFI1V0VrS1ptVkZNbFV3TURadmJHMUlOVzV0U0V0TVYyaE1OWGRsVUZGSFZIZG9jWHB3VFRneFZuTlZNbUp2VEZoaGNHcFBSR0pCTkd4MllWcHNPQzk1TW1SNGR3cFFPWEJ5ZGxaWGJFNWlOM0pHVmpCck1YRlZaWEl3T1N0RWNtdGpOWE5hWm1WUU1tdEdSbWRUYzJaTllsaHRTVTVTTldWcWExZElPWGw2VkRRellqTlhDbVpIVjJ4a1JVWllNMWRUYVUxaWNWa3dVekU1WTJaUlJFVkRMM0ZHWmxscVYwZEthbmwxVFdObU5XWmFNMmQwWmtka2FGbEJkVWhsVVZseVF6ZzBXbkFLWWsxaU5UbDNRVXRHZWxGeVZEbE5NbVJyUVRGYWFtOW1SRU5WWTJSc2VGbDJkekF5TDNCWVkxVTRWRWxwUjBWeldYQkRlbFp4SzBsa1Z6bDZPVGRpV2dweGFERktTRzVOT0dRdlIwRllTMWx4UkRVNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNqVjNWMEUwU0hWM1dEZGpWVXRQWVhabWFXMTJWMGR5TTA1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFXcFVORFJ3ZWxwdU5WcExOVlZ0YkRONlptdHBkR0ZuVkhseldFbHJXVEZpZVU5b1lYcGFNRWh0WjNGa04yUnpaUXAzVm1FclUwdEVWbnB3Ym1sTWNHRmhVM0pUYnpaeGVUazRXVEppYkVWTGN6WkRSWEpJYzJRME1XNHZRbVE1Y1RaSmRrMWhZbWhhYm1SMVEwWXdjREJQQ2t4NlIwSndRWFUzTldKckswZG9RVWhvTWpNdmRrOUJaa1VyTldoNVFqbDBZMlJ5VTJOS2RFTkJURmh2VW1VM2EyWTRZVzB5ZURGbVFXTTFMMmd4U204S2RsaE5jMVpQTmtGdVUyZEpVRGRSY25kU2FHMUlhVkYwWW1KdFJYbDZSMlZsZFVSWldYaEVSMU5RWkRaME9HOWlORzFrZFd0YVVXdEhNbEJhY0ZsT053cEdWRXBGUWpOTmNVcEZkR3BLV2poWVNVWkxibUUxVW5nMlFWWnBUV0ZLZVdoeFVqTktVblpCSzB3eGFXZ3hiM0l2UkRaUk9GTjNWRzlyZDI0MFUwWXhDbmxuYVVsUmNrRnBVV1J3YmtKRFZsUTVTWFYzUlZOb2VYSm1VelZqVEdGd1VWTjJOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjllZDk3YzMtZjM3MS00NmM0LTk3YjUtZjkxNjQ2ZDNkZjhkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPeWRjaDdoNzFweExGTERuZnl0V2pLU2hDOW1hVWZabHhjSEJJOWRVMFFaY1ZkQ0RyajJzRk9zcw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:21 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34fdae59-bd59-4e64-89f5-c4bd7633a3eb
+      - 6d8b1770-fa7f-41cf-9711-0716fcfb86b7
     status: 200 OK
     code: 200
     duration: ""
@@ -911,19 +911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c371b92c-382e-41b0-a8c8-ffd73198f254
+      - 88b0ab49-f4f2-4d4d-b53c-df90776ba9a5
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4416849-7852-44af-95dd-0cd4cb48afbf
+      - 0e56220d-2d35-436e-a245-52bd31b50988
     status: 200 OK
     code: 200
     duration: ""
@@ -977,19 +977,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c222f5fd-3420-419a-8943-881d08ceef16
+      - ab467d2d-7680-426a-a5ca-5f50b6a2b0d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,19 +1010,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a884ac0a-a68d-4960-860e-89773542c584
+      - 18cab11e-9416-4038-8ef2-b79f1097dbe0
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,19 +1043,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "705"
+      - "722"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0ea4fea-2352-4fbe-9153-5f3d52b42ea0
+      - 50d38e18-0d91-4769-be52-03c31d89cdea
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,19 +1076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fbd2e77-ab23-472d-85a0-0cc1b07a313f
+      - d6316d49-82f2-4e72-9d0e-3b0f695b1c11
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1478"
+      - "1523"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:22 GMT
+      - Fri, 10 Nov 2023 13:17:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263db28f-9b4d-4b2c-84b1-766bd5695b0e
+      - 869f2850-83c9-4567-9dc9-ed113305d299
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,19 +1142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJlRTlHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0Y0VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWG80Q2s1R1kwOUVWRXh6UVM4dkwzbEtWa3hvVERoc2JtazJlRlJLY1cxRWNrMXVPR1kwUTIxWWFXSm5NRzgxWmtkalJHRkpiMEUwVGswMFUwWkVaR05EU0U4S2RUZENVRlJvZG5Od2FFVnBVbUl4WXpCMGVHcGlUVFJIUzA1d1lVRmxkVVJpYm14SmMwZDFNSFZwUVd0a2EzVTRiM1JvVTJZdlMzbHNkU3N6Y2xwWlRncHFiazVYYkVSbVMyNVNieXRZYVVGdk5XOURVMDVDTkdOdFMxcE1aMFF4YjI5Q1JXWTFaMHhHVmk5cWNGSjFiV0ZQVWpSSGRuazRMMlF4VWtGMk1qWlJDakpJVjNoNlZuTnpkRWg1TVZWRlEyRXllakpHWVVZcldYbzVhVmRXUm0xcVQyVnlTMU5tZDFsMlYyMVJZa2RIYzA1aUwzWkxkVzlhYzJsbFlVZDVVMndLZHpWS00wbHFVRkV5UkM5MVZsWnJibEZXVVd3M1lUUmFNMDE1ZURoSFFYb3JWblE0V0UwNWRuRnpNWEJxT0RCTVdGWkxUa1JPYzFrM2FFVlhjWGRWWmdwalR6ZFRiRXBuVW5GRU9HMTROSE16TWtSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVptcFRWMGxJTUcxWVRGQTBlVEZKU201RlJEVXZMMkZ4WTJoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJERlpUbWw1ZVd3ek5UQklSR2xqV0V0TWFrY3pWVmhyTlZweVJHTTFhRUpDVGpnM00xWXlOV2t3WTNFek5teDRTZ28yUldwQkwweEpWWGc1V0Uxb1JVVmhXV05DZUhKMU1FOVRlbkpqTlRCdFdWRjBlWEpCUm1wcVMxQlViVmhPYkhFNVEySkxVMGRpVEhFeGRsWkxPR0pNQ214VFZWbHZiVTlIWkdkc2FqVnRORFJUZFZOcGJtVmFRV1Z2Tmt0ekswSlVhVTk0ZGs1M1ZrbzJWVEUwT1ZSaU5GUlFabVE0VFhRMU1XZ3JRME5ZUWxZS1VYVlBUSGxHTUZOc1RsQkhLM013WmpoMWNVTjJVWFJHV2psbFpFNVZaSEZtVW5aSVoxTk9hbE5SZWk5b1p6TXZaV2RDYjNoTFZUQnpPWGRuV1hkTU1ncDNTRVJYYW1STFZUTmhkbFk0WnpnelZXeDBSVFpPUzFCVWQySndZbTVHVTJscWQxVXhaRWhJTmtWck5IVm9SV1ZFT1RaWmQzUmhRMjA1YlRWM1JrNUtDbE5zUW1Sd2IwaEVkVTV1TDJRcmFXOVNWSEZsVUhadGJ6VmFNM1E0YzJ4WmIzaHFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzYzZmU0MDQtMzZjNy00YzkyLWEzY2EtZGFlZDVkMjE4YzYzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0clN1RDJhRjF1NEZic2M1WWtLdlhwS0lKbVJhSDg4WHZidXlCVUV6WHZ5bng5RjBCVmRFS0h3ZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplRTR4YjFoRVZFMTZUVlJGZDA5VVJYcE5WR040VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWEkxQ2preGJVUldiSE5TUjFkQkwwOUhkemwxT0ZaTVptcERhekpTV1ZBNFNVOWFObWx1YUhRMVFUZGhaWEpsWm10VlZTdDNjbnBTUTBsNk1VUlRjRFI1V0VrS1ptVkZNbFV3TURadmJHMUlOVzV0U0V0TVYyaE1OWGRsVUZGSFZIZG9jWHB3VFRneFZuTlZNbUp2VEZoaGNHcFBSR0pCTkd4MllWcHNPQzk1TW1SNGR3cFFPWEJ5ZGxaWGJFNWlOM0pHVmpCck1YRlZaWEl3T1N0RWNtdGpOWE5hWm1WUU1tdEdSbWRUYzJaTllsaHRTVTVTTldWcWExZElPWGw2VkRRellqTlhDbVpIVjJ4a1JVWllNMWRUYVUxaWNWa3dVekU1WTJaUlJFVkRMM0ZHWmxscVYwZEthbmwxVFdObU5XWmFNMmQwWmtka2FGbEJkVWhsVVZseVF6ZzBXbkFLWWsxaU5UbDNRVXRHZWxGeVZEbE5NbVJyUVRGYWFtOW1SRU5WWTJSc2VGbDJkekF5TDNCWVkxVTRWRWxwUjBWeldYQkRlbFp4SzBsa1Z6bDZPVGRpV2dweGFERktTRzVOT0dRdlIwRllTMWx4UkRVNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNqVjNWMEUwU0hWM1dEZGpWVXRQWVhabWFXMTJWMGR5TTA1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFXcFVORFJ3ZWxwdU5WcExOVlZ0YkRONlptdHBkR0ZuVkhseldFbHJXVEZpZVU5b1lYcGFNRWh0WjNGa04yUnpaUXAzVm1FclUwdEVWbnB3Ym1sTWNHRmhVM0pUYnpaeGVUazRXVEppYkVWTGN6WkRSWEpJYzJRME1XNHZRbVE1Y1RaSmRrMWhZbWhhYm1SMVEwWXdjREJQQ2t4NlIwSndRWFUzTldKckswZG9RVWhvTWpNdmRrOUJaa1VyTldoNVFqbDBZMlJ5VTJOS2RFTkJURmh2VW1VM2EyWTRZVzB5ZURGbVFXTTFMMmd4U204S2RsaE5jMVpQTmtGdVUyZEpVRGRSY25kU2FHMUlhVkYwWW1KdFJYbDZSMlZsZFVSWldYaEVSMU5RWkRaME9HOWlORzFrZFd0YVVXdEhNbEJhY0ZsT053cEdWRXBGUWpOTmNVcEZkR3BLV2poWVNVWkxibUUxVW5nMlFWWnBUV0ZLZVdoeFVqTktVblpCSzB3eGFXZ3hiM0l2UkRaUk9GTjNWRzlyZDI0MFUwWXhDbmxuYVVsUmNrRnBVV1J3YmtKRFZsUTVTWFYzUlZOb2VYSm1VelZqVEdGd1VWTjJOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjllZDk3YzMtZjM3MS00NmM0LTk3YjUtZjkxNjQ2ZDNkZjhkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPeWRjaDdoNzFweExGTERuZnl0V2pLU2hDOW1hVWZabHhjSEJJOWRVMFFaY1ZkQ0RyajJzRk9zcw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:23 GMT
+      - Fri, 10 Nov 2023 13:17:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b1be42c-b541-4db3-b546-12601b242e32
+      - 8f5fed1e-5e35-4426-a21d-afda3921b5d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,40 +1175,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63?with_additional_resources=false
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461188Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1476"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:20:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aadc5f24-c947-4703-8491-cb78a6de0c67
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: DELETE
   response:
     body: ""
@@ -1218,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:24 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9237f4a9-5bcc-46e8-ae79-cf7064a27cb8
+      - 325a04eb-a769-4519-95b1-3218ecd95388
     status: 204 No Content
     code: 204
     duration: ""
@@ -1239,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d?with_additional_resources=false
+    method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546408703Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:24 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eabe3be-3347-45ac-9c7c-3b2ad2138181
+      - b73b5e17-ff5f-478c-a449-0f97d5c17862
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:29 GMT
+      - Fri, 10 Nov 2023 13:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 319c3323-ae67-48d6-9d3e-32b5ccccbce2
+      - 5e1330d2-aa4b-4b78-abed-b78b7dd991e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1272,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"363fe404-36c7-4c92-a3ca-daed5d218c63","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1518"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52dd470b-a482-4e64-a0a4-5700911df06a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1518"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 062e36a3-aa97-4f30-88a0-71d0ca895d03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1317,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:34 GMT
+      - Fri, 10 Nov 2023 13:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 816e6a3b-fb4e-4e03-9638-34d4c752a937
+      - e7239539-807b-4242-b45c-ae1c94965e30
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1338,7 +1371,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
     method: DELETE
   response:
     body: ""
@@ -1348,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:35 GMT
+      - Fri, 10 Nov 2023 13:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19dbd95e-23e6-4997-9e77-f4c5f337ed2c
+      - fb3c5523-bf39-4014-870b-464093dbf9a4
     status: 204 No Content
     code: 204
     duration: ""
@@ -1369,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"363fe404-36c7-4c92-a3ca-daed5d218c63","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:35 GMT
+      - Fri, 10 Nov 2023 13:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1424,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3807c22d-4958-426d-9d73-d480e4a9cbf9
+      - 296d0482-3832-4bf3-b416-2ab9511b2a4b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adf64237-d1f9-4b1e-87b1-cc6b9d13a152
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0cbcac9c-7ed5-4e03-b8e4-98f52398b867
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:19:57 GMT
+      - Fri, 10 Nov 2023 13:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 191b76e5-c2c3-49f7-b5c9-bdc70472b845
+      - 706d0df8-4d41-4314-a760-319029875e83
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "700"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d07bb328-3562-4d38-920c-33faeeaf4f3c
+      - 26214f22-0980-48ce-b97a-e4df1b555cd8
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "700"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a36700e-82d5-43d2-b044-ccc538847e95
+      - 912c7faa-9b7d-4754-b99a-4b22ccc11334
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701149788Z","created_at":"2023-11-07T16:20:00.701149788Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:00.713800316Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486464737Z","created_at":"2023-11-10T13:16:58.486464737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.499426405Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c98f2ff6-3a09-4ab2-9061-c1a65822b1f7
+      - 877766cf-14ea-43ed-8435-7bf6cbe81dcd
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:00.713800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.499426Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:00 GMT
+      - Fri, 10 Nov 2023 13:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 835b6a31-6d67-4e7b-85a2-3e5042233d77
+      - 3b9991bd-4582-42ae-b72c-63504be486da
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:05 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55db3779-467f-4596-9748-74797c6877d2
+      - 2fcefd0f-d682-4a14-9171-956d418e9372
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:05 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d791340e-cd7d-43d2-8c3d-d7cdde00c790
+      - 539d0e40-4e0e-46b6-b7f7-47ba17071b48
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d0bf3fb-6828-4b2e-9098-6fdc05305a84
+      - 575ba852-29bf-43f9-a227-59881fc1968f
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be66c245-5045-40f1-b2b3-fa0cfd06944a
+      - 24ecb0ed-b369-44bd-a1f3-45f728b43753
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "700"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fcdeafb-46cc-482d-aacd-b97f0cd189b9
+      - 9f9752d5-e2de-4ca0-a228-120af7185b9f
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ed2d4b0-4ea6-4c7e-a323-423acf3bb7cc
+      - f5040722-fab8-4605-9a08-90a9fb20b21b
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:06 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bef6665-306d-4e70-8977-19d4f7847a4e
+      - 7d7ae551-4f30-44c4-82dc-1708f8b0aa19
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "700"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4cf0711-3b07-4274-bf48-d62bcef90d45
+      - dab7299c-c2aa-4a24-ad62-5e4ec55c7f40
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1463"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecef82b6-4bd2-4118-b6ed-f40d60700cb4
+      - 735afd6f-4d81-4715-9232-f1e416208ad2
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a6df06-cf20-4c61-8b35-929f5052d981
+      - 80f57acf-8682-40f5-a56f-b24e177ca51c
     status: 200 OK
     code: 200
     duration: ""
@@ -511,52 +511,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
-    method: GET
-  response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
-    headers:
-      Content-Length:
-      - "748"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40e9bd1c-c90a-4237-b383-87cb3bee4356
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "748"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:07 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e50db1c-8ec6-4448-a7c4-70f69e6e63a2
+      - be123893-75cd-46f4-8abb-e7b108a84771
     status: 200 OK
     code: 200
     duration: ""
@@ -577,19 +544,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "748"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3865e472-ba3b-4f52-aeaa-39eb45f1e3fa
+      - eef07048-512c-4cff-9c4a-0bf766b52b75
     status: 200 OK
     code: 200
     duration: ""
@@ -610,19 +577,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "1463"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +599,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceae607d-8cc5-4a17-b227-591458c7b0b7
+      - c219f084-c50e-4177-8829-b980e0df7b53
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1508"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:17:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 887df2b4-748d-4d45-8285-5e99e3ff87e2
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445498Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454120971Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263957800Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892452Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ed22e1-def7-4154-863a-8ed7ac2be693
+      - 71baec61-2f45-453f-b915-169a242f4a97
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:08 GMT
+      - Fri, 10 Nov 2023 13:17:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 890fefc7-79a8-402a-b30c-d056dfecf655
+      - 8e515db7-588c-416c-8399-fe4a49d593d6
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:13 GMT
+      - Fri, 10 Nov 2023 13:17:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6190397-6f2c-470a-a656-437aad75eb02
+      - d358ee9a-beaa-46fa-be0c-80880bedf4d9
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:18 GMT
+      - Fri, 10 Nov 2023 13:17:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79b091e1-8c3e-4dee-9b6c-6b06548c355a
+      - 99a4ac89-67cd-4693-82a7-1b3a40c21c81
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:24 GMT
+      - Fri, 10 Nov 2023 13:17:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d05a506b-2f17-43a4-b851-000997aeb1b1
+      - 73b4ea96-3adb-491e-bd07-cc9b9d82ab4e
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:29 GMT
+      - Fri, 10 Nov 2023 13:17:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 869778e6-872c-41d9-a538-f28f5582a9f6
+      - 68af9d99-4aa3-49d9-9748-da8483e455f2
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:34 GMT
+      - Fri, 10 Nov 2023 13:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c76706cb-e20c-4efa-9967-bf8f5b1d8499
+      - 1321cd3a-f65d-4aa7-bf9b-96d27b671d8d
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:39 GMT
+      - Fri, 10 Nov 2023 13:17:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5afbcc0b-ce6e-40d0-bcb4-a3ebe9d34bcb
+      - 89911edb-dbfd-4a79-bf16-fd826cf7f466
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:44 GMT
+      - Fri, 10 Nov 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63d4a9f5-d3c9-4f02-aa05-599c1acba71a
+      - da164e64-034c-45be-b4a0-8c322c919455
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:49 GMT
+      - Fri, 10 Nov 2023 13:17:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce0fc65d-d4d4-4429-ae75-8ddef4ccb475
+      - f299ed08-00bc-4138-980b-36210ac53052
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:54 GMT
+      - Fri, 10 Nov 2023 13:17:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d95bba73-85bf-4e21-a197-72c92346b861
+      - ae5fe2f7-5d7f-4867-9826-a77079ed5ffa
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:20:59 GMT
+      - Fri, 10 Nov 2023 13:17:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 927931d5-1f11-4cbe-8132-c1d7fda5152d
+      - 9580e5e1-9a44-46a6-ab39-cebb56ac1e0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:04 GMT
+      - Fri, 10 Nov 2023 13:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8cfe723-5449-4f09-a33a-54feb7ce8810
+      - 8e71e87a-22ec-4171-8398-73e0808dc146
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:09 GMT
+      - Fri, 10 Nov 2023 13:18:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 564f0ba6-b86c-477c-9811-8502d6f79a0e
+      - 613b4cf6-516a-4896-8a46-e490615b9513
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:14 GMT
+      - Fri, 10 Nov 2023 13:18:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5358b7da-1d33-49de-8308-ef8c396dfdfa
+      - ba1b9a2f-76ab-4acc-bc4a-ea0f1347417d
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:17.092870Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:19 GMT
+      - Fri, 10 Nov 2023 13:18:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92af251c-3c00-4e76-8b7c-89d04e73cc83
+      - afc03345-6496-4025-9a62-f27ba9a71da6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:18:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4fc7403a-5bdb-4d97-9ada-b7a546811558
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6f61c38b-2d3b-4a08-9739-42509a003af9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:30.290815Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1512"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:18:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a961cf63-f6e3-4d02-bf88-629acbdb806f
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,19 +1274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044164Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:19 GMT
+      - Fri, 10 Nov 2023 13:18:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9930bfe-1008-4e6a-97da-5e73c738bfc5
+      - 9addc38f-6f7d-467c-a591-80042994adb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,19 +1307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:19 GMT
+      - Fri, 10 Nov 2023 13:18:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9cfa96c-6d2f-46aa-856e-1aa8b9f2ed09
+      - f3653cc9-5e6d-412e-ab04-2ff7873c61b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,19 +1340,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:24 GMT
+      - Fri, 10 Nov 2023 13:18:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1263,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f1cafb9-9de5-4373-9e37-cb2d06a1fc8d
+      - b26358d3-bb17-4686-b87a-4057d6f4cb76
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,19 +1373,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:29 GMT
+      - Fri, 10 Nov 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cd12ca5-8531-4599-b66f-f11199798053
+      - 938f3b5a-0502-430a-a653-871748940053
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,19 +1406,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:34 GMT
+      - Fri, 10 Nov 2023 13:18:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf837362-acca-4386-852b-108c31210a2e
+      - 3c17cc78-2fde-4c2c-a747-4dadaeacfe4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,19 +1439,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:39 GMT
+      - Fri, 10 Nov 2023 13:18:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a9b557d-daed-414d-a3f5-080ae58cf161
+      - 234bcce1-6153-4400-817a-fcf2c2d7c64d
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,19 +1472,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:44 GMT
+      - Fri, 10 Nov 2023 13:18:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95e1cccf-7b9d-40c1-ba28-cc5c33c272bf
+      - 8b2956af-f6f5-48a4-97e8-32d6bec56bb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,19 +1505,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:49 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95c5c9ca-7a66-4c38-ab6a-9274c64432df
+      - b7d73fbe-0fdc-44bd-b545-a6b0d192ed6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,19 +1538,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:21:54 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91539e3e-0676-4e82-8d52-899d482c7726
+      - 929eadcc-c5d3-4a67-92cc-d02ef6d56ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,19 +1571,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1470"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:00 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee7c9b83-765e-4a35-a4e5-bd5ae7ad1133
+      - 2e4f13a0-532b-4c87-900c-9f209aa54980
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,19 +1604,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:05 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceb52a16-9069-4671-aa53-55665eac0a22
+      - 85fa7d1e-366b-458e-8398-f8bd170b92a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,19 +1637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1470"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:10 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25a70695-9944-4d4e-b49c-12cd9a774dbb
+      - 8099edde-d219-4db8-8e6b-33bafca5acbe
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,19 +1670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
+      - Fri, 10 Nov 2023 13:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bc7849f-80c4-48e6-8cc2-23ff32a31131
+      - ac157ccf-8901-4fec-949e-6bcb6641462f
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,19 +1703,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1467"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
+      - Fri, 10 Nov 2023 13:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cc20d50-ad54-4414-8d80-381b1b78985f
+      - d4ed33e2-d6fd-4a69-957c-e307d312b7c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,19 +1736,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2620"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
+      - Fri, 10 Nov 2023 13:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff7a2b0-bd51-4752-89ba-bab7d220b100
+      - e31c37c9-f5e4-44e8-935b-689146ab7f1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,19 +1769,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
+      - Fri, 10 Nov 2023 13:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1692,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7984e50e-e3ad-4229-88c5-f210414ea270
+      - a8f639b9-562b-4fb4-a845-1c16ac288d29
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,19 +1802,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "700"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
+      - Fri, 10 Nov 2023 13:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1725,7 +1824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3413446-1d1a-4263-ba85-446e00c15dd4
+      - 4aabb25a-8f59-4087-adf1-0ec7adfe2885
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,184 +1835,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 096a56b8-b098-4568-b9bb-566589db1618
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:22:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fbb7c909-a8e7-4de5-87d7-6925d6469b21
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90879aa0-90dc-42bf-8673-c13b647afee2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a1e94df-bdca-46db-8c8c-778711428d21
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ce662dd0-20f8-4a87-a459-13ea858d69ba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "407"
+      - "423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
+      - Fri, 10 Nov 2023 13:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1923,7 +1857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c9e4b0a-0696-4b9b-8745-e9b1b60b22f7
+      - 5854b479-98e9-4bb1-9ebf-6eca8c985a28
     status: 200 OK
     code: 200
     duration: ""
@@ -1934,19 +1868,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "407"
+      - "423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:16 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1956,7 +1890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eb8fce1-77e4-4750-a096-b744d05df93d
+      - 7075ceb0-b2b0-4487-8977-b5af710406f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1967,19 +1901,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "407"
+      - "423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:17 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1989,7 +1923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72a9ef07-0dff-40d1-b0c9-cff4a38c29f0
+      - bd72aaa3-53d0-401e-8d7e-93ed204e3e66
     status: 200 OK
     code: 200
     duration: ""
@@ -2000,19 +1934,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:17 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2022,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc0e00f4-426b-4ae2-8467-4cf78aa712b4
+      - 117560b5-a047-409c-b856-7b260175e8b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +1969,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527638748Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109254Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503659860Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586977848Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1477"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:17 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 336b159b-73b1-4bf6-87c3-1e8477bc4fd8
+      - d64f356f-4ed0-4357-95d8-aa9ad275b627
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2002,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:17 GMT
+      - Fri, 10 Nov 2023 13:19:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 180e942f-39b8-4ccb-af15-a9577c5865ec
+      - 4f1d2e47-860e-4f4a-8408-ad779390b992
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:22 GMT
+      - Fri, 10 Nov 2023 13:19:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dc5eb26-92dd-4632-94b9-b4cd16fcb6dd
+      - 9f5b71ee-c180-4fce-8d30-6d04696efd61
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:27 GMT
+      - Fri, 10 Nov 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c611e5e9-b131-4aa2-bb1b-af4bc4f2f6ac
+      - b57be703-1fb0-4c2c-a0cc-5a4468fc57de
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:33 GMT
+      - Fri, 10 Nov 2023 13:19:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5439940a-6c88-4789-8d02-86542ba7470d
+      - e84571a0-5dc6-4c2a-98c2-d9f325f81794
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:38 GMT
+      - Fri, 10 Nov 2023 13:19:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52ca8be8-2707-440f-8dc4-80ebc48010d7
+      - 2c259b5a-86dd-4cbd-aeb2-bf26977e614e
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:43 GMT
+      - Fri, 10 Nov 2023 13:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a2c4ed-de8e-4dbb-8a4b-c642904f8355
+      - 080abb38-2aa3-4b51-b853-c11be055f161
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:48 GMT
+      - Fri, 10 Nov 2023 13:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9ffe454-09de-4aaa-b6cb-fd566cf6f540
+      - f2e74cce-48b6-401f-a407-1d3e3b8fc39b
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:53 GMT
+      - Fri, 10 Nov 2023 13:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5944bcec-20f8-4f8f-88cd-1339c49c667a
+      - 7136c438-967c-4cc5-a7cd-6d46f59ff045
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:22:58 GMT
+      - Fri, 10 Nov 2023 13:19:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2c7a4b0-1359-4f26-af74-60e1bb4aa0e2
+      - 0b4f20a5-bf9a-4173-921f-c2ac5604ee01
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:03 GMT
+      - Fri, 10 Nov 2023 13:19:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1662cf30-195c-42e3-947b-81149ad24fed
+      - 2b5fb1bc-8973-4187-99e1-ef11b6c4e02d
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:08 GMT
+      - Fri, 10 Nov 2023 13:19:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0adf2ac2-c856-4595-b150-788a81f34eaa
+      - c8cc033b-06ce-4522-8728-5599bdebc14e
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:13 GMT
+      - Fri, 10 Nov 2023 13:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc70c54a-7048-45eb-a24c-a72d4e6d9920
+      - 70ab7ac7-c93c-428d-a2ed-4971f1cd640b
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:18 GMT
+      - Fri, 10 Nov 2023 13:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8fd21ea-e002-46a7-8a9e-eaf7e4f543fe
+      - 742c2033-2036-4474-a533-c4fa22e84b3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:23 GMT
+      - Fri, 10 Nov 2023 13:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe802158-1edf-4a59-a66e-f0721462eb55
+      - 9e602929-3d99-4f30-9647-bb57d1df6030
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:24.762360Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:15.367031Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:28 GMT
+      - Fri, 10 Nov 2023 13:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f945ff3-ed62-4295-9192-4f86dbb7b12a
+      - 803655a0-9cac-400a-87cc-bb6b922e36f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2565,19 +2499,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554338630Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:28 GMT
+      - Fri, 10 Nov 2023 13:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2587,7 +2521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9afd57af-04b3-494c-ae0e-2377a8ecb9d1
+      - d68e8330-55d0-4232-99f6-1233fddbc09b
     status: 200 OK
     code: 200
     duration: ""
@@ -2598,19 +2532,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:28 GMT
+      - Fri, 10 Nov 2023 13:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2620,7 +2554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c83b5d3-11fb-46cc-9022-acf677a8c97e
+      - 8475ca12-ecf6-401c-97a1-bcdb8a8945f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2631,19 +2565,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:33 GMT
+      - Fri, 10 Nov 2023 13:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2653,7 +2587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9920ec5-2f5e-45b6-8a77-9c8734138656
+      - ef99598f-bc2f-49c0-9f0e-058103404456
     status: 200 OK
     code: 200
     duration: ""
@@ -2664,19 +2598,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:38 GMT
+      - Fri, 10 Nov 2023 13:20:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2686,7 +2620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48997637-4d6a-4b4f-afd1-084ca30b474c
+      - ea2ec300-7bd9-422d-b1bc-2dcd3b6a2e70
     status: 200 OK
     code: 200
     duration: ""
@@ -2697,19 +2631,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:43 GMT
+      - Fri, 10 Nov 2023 13:20:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2719,7 +2653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c9520d8-66d8-41e8-a012-e07858f7f762
+      - 2c76d764-dd13-49a2-a801-2f2b7a29f78d
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,19 +2664,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:48 GMT
+      - Fri, 10 Nov 2023 13:20:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2752,7 +2686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dbd1458-6be2-4a27-8570-369aa80392fa
+      - 4d16d8e2-0c78-478b-b6a3-06a2847bcf99
     status: 200 OK
     code: 200
     duration: ""
@@ -2763,19 +2697,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:53 GMT
+      - Fri, 10 Nov 2023 13:20:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2785,7 +2719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77171913-ebcc-4efe-b045-0d5607974e03
+      - 8ecfd435-fd5f-4580-9953-828820924009
     status: 200 OK
     code: 200
     duration: ""
@@ -2796,19 +2730,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:23:58 GMT
+      - Fri, 10 Nov 2023 13:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2818,7 +2752,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a26c5b54-3a55-4d94-99e2-afe79f083f9f
+      - ac2e36c4-cbf9-4668-9b08-e1f3d332a1e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2829,19 +2763,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:03 GMT
+      - Fri, 10 Nov 2023 13:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2851,7 +2785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38cb10c6-7178-49b3-a163-8b6c4eee591d
+      - fdcef856-ef16-429e-99e5-63d41ae959b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2862,19 +2796,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1468"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2884,7 +2818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24887a29-be67-4d7e-a366-e0caee6b712a
+      - 77ba5668-6e75-4199-b725-2d3a2acc3a75
     status: 200 OK
     code: 200
     duration: ""
@@ -2895,19 +2829,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2620"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2917,7 +2851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51eecd34-3a39-49cc-be43-d3053e58486f
+      - dcac7646-bd39-40c2-b060-c17f7587ecd5
     status: 200 OK
     code: 200
     duration: ""
@@ -2928,19 +2862,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1468"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2950,7 +2884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ffbb5ed-f1a0-49b9-a09a-54204d1c5b24
+      - 2aa97384-1103-485e-bb3e-c2d38aabfaa7
     status: 200 OK
     code: 200
     duration: ""
@@ -2961,19 +2895,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "700"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2983,7 +2917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59ed9774-e2ac-455e-a88f-58100c221baa
+      - 7ed01cfc-897b-45ef-977a-2c99f5def52b
     status: 200 OK
     code: 200
     duration: ""
@@ -2994,19 +2928,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1468"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3016,7 +2950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 902221d8-b5f9-4175-8755-79d6fe57bfee
+      - ae043af7-9a98-4294-97c1-32eac8275408
     status: 200 OK
     code: 200
     duration: ""
@@ -3027,19 +2961,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2620"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:04 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3049,7 +2983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce18feb1-2281-49d8-9787-f6ce9d526242
+      - f5c376d2-714e-41fc-bca4-478f1f90dbba
     status: 200 OK
     code: 200
     duration: ""
@@ -3060,19 +2994,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "700"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3082,7 +3016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a12f690f-58eb-4f32-b2f9-30d324fae2a7
+      - 45130f25-209c-45e6-8b7c-db0b73bb429a
     status: 200 OK
     code: 200
     duration: ""
@@ -3093,19 +3027,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1468"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3115,7 +3049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6aacfc0a-d68f-4647-9102-ebb929b30efe
+      - a692ef05-5fcb-4f12-b54d-29e9d4441a5b
     status: 200 OK
     code: 200
     duration: ""
@@ -3126,19 +3060,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2620"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3148,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be8f7429-1eb7-4753-b37d-2c9c9ad826c9
+      - 715fe79d-cad0-4955-9a39-8aa75299a306
     status: 200 OK
     code: 200
     duration: ""
@@ -3159,19 +3093,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2622"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:20:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ca29c12-962d-424d-9269-2d19ea6c7fbe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
     headers:
       Content-Length:
-      - "36"
+      - "37"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3181,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 340aa7aa-e53b-4257-a577-07ba52e213b5
+      - 008b9254-b212-44f7-a444-b5e75049d460
     status: 200 OK
     code: 200
     duration: ""
@@ -3192,19 +3159,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
     headers:
       Content-Length:
-      - "36"
+      - "37"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3214,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e65f0436-4153-4473-a725-2971c7528ad8
+      - 22d97707-53ae-417e-8358-9f0e17bd5836
     status: 200 OK
     code: 200
     duration: ""
@@ -3225,19 +3192,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847617783Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804934640Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1474"
+      - "1519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3247,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74f75e44-1ba0-419e-8c2d-d34d1b58107f
+      - d9434834-fa57-4a3c-9ee9-7770b756d991
     status: 200 OK
     code: 200
     duration: ""
@@ -3258,19 +3225,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847618Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804935Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:05 GMT
+      - Fri, 10 Nov 2023 13:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3280,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dad27172-e169-4d97-ba1a-7cb8c8edf813
+      - b8551bea-81ff-4ac5-a214-762492fad9b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3291,19 +3258,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847618Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804935Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1471"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:10 GMT
+      - Fri, 10 Nov 2023 13:21:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3313,7 +3280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 090630b1-0fbf-4f9f-a9e0-7253fa3533f6
+      - 7aab22d8-f8a1-4924-8acb-44930a6de7d7
     status: 200 OK
     code: 200
     duration: ""
@@ -3324,10 +3291,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3336,7 +3303,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:16 GMT
+      - Fri, 10 Nov 2023 13:21:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3346,12 +3313,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f49263c-1b8f-4c4d-88df-9670c71be721
+      - db6fc4bc-d83b-41f6-8dda-6bd56a5f2fea
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2"}'
     form: {}
     headers:
       Content-Type:
@@ -3362,16 +3329,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828085Z","created_at":"2023-11-07T16:24:16.189828085Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004268Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070371Z","created_at":"2023-11-10T13:21:09.134070371Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250399Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1524"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:16 GMT
+      - Fri, 10 Nov 2023 13:21:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3381,7 +3348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ea97534-3af2-4ec6-bbec-8f71e63c4d7a
+      - 97afb1c4-6f0b-446a-85b2-8cbc59ca6c72
     status: 200 OK
     code: 200
     duration: ""
@@ -3392,19 +3359,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:16 GMT
+      - Fri, 10 Nov 2023 13:21:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3414,7 +3381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4ce5953-3fb6-4b0a-a8af-4d60d4b511a1
+      - 0d7c765c-d289-44e4-96f9-07d78f3d9bac
     status: 200 OK
     code: 200
     duration: ""
@@ -3425,19 +3392,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:21 GMT
+      - Fri, 10 Nov 2023 13:21:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3447,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c56e04d-7d22-4d9d-a029-e36f0409086b
+      - a04db758-f426-4cbd-ad28-f66283b12a37
     status: 200 OK
     code: 200
     duration: ""
@@ -3458,19 +3425,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:26 GMT
+      - Fri, 10 Nov 2023 13:21:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3480,7 +3447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce5ed4be-b473-4cfa-ad04-3fb18751deca
+      - bdf5ca20-76bc-41be-8cb0-90a09e937057
     status: 200 OK
     code: 200
     duration: ""
@@ -3491,19 +3458,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:31 GMT
+      - Fri, 10 Nov 2023 13:21:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3513,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fa6df5f-32b2-493d-aa45-9d5692c8df1d
+      - 35c98251-d266-4a26-8f9e-abaf5ae98467
     status: 200 OK
     code: 200
     duration: ""
@@ -3524,19 +3491,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:36 GMT
+      - Fri, 10 Nov 2023 13:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 356d73b7-fea7-4074-b4ab-92238bdc5230
+      - 8fae860d-5bc0-449f-9931-aa2b7a12a6d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,19 +3524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:41 GMT
+      - Fri, 10 Nov 2023 13:21:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3327920c-d7a5-4183-8fe5-281998e73719
+      - 74795e1e-36cb-43e8-8e2f-81c5840ef1b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,19 +3557,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:46 GMT
+      - Fri, 10 Nov 2023 13:21:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3612,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa693255-5ab4-4faa-9dba-1096e20258da
+      - 64ef6147-ded3-405a-a52d-6d06d99d201f
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,19 +3590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:51 GMT
+      - Fri, 10 Nov 2023 13:21:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8489452b-0abe-4096-9df5-d28b08076848
+      - 920f7d9a-762c-4577-85ba-a6ee0651bb0e
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,19 +3623,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:24:56 GMT
+      - Fri, 10 Nov 2023 13:21:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +3645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a787b1be-e0c0-4d6a-8527-40ed4a7a49d8
+      - e4e7c313-782f-4f94-8687-97e4f81ecde8
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,19 +3656,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:01 GMT
+      - Fri, 10 Nov 2023 13:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,7 +3678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a816ba2b-c9cf-40c8-b481-2fa9daba30e4
+      - cfcf2245-1161-41b1-bb7c-fdfa4fe86026
     status: 200 OK
     code: 200
     duration: ""
@@ -3722,19 +3689,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:06 GMT
+      - Fri, 10 Nov 2023 13:21:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3744,7 +3711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56a1fd88-f55f-47b5-9d9a-fbfedc4e4206
+      - 5e4e5a40-47b0-4d3d-902b-79f6a946c91a
     status: 200 OK
     code: 200
     duration: ""
@@ -3755,19 +3722,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:11 GMT
+      - Fri, 10 Nov 2023 13:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3777,7 +3744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b169e65-ee80-4b3c-a328-14831b6fb281
+      - 45ffd5ed-ace7-4726-a07e-f0c7814ea52e
     status: 200 OK
     code: 200
     duration: ""
@@ -3788,19 +3755,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:16 GMT
+      - Fri, 10 Nov 2023 13:22:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3810,7 +3777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a83ba6f9-11c8-44f7-b7ab-eb5f8ab31399
+      - b267d733-14a2-448a-9fc3-c07c265c7b66
     status: 200 OK
     code: 200
     duration: ""
@@ -3821,19 +3788,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:21 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3843,7 +3810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dffd0bec-c737-40ec-a33a-e4a40baa49cd
+      - 4fe7e075-19bc-455e-ba18-0872d16eb4d5
     status: 200 OK
     code: 200
     duration: ""
@@ -3854,19 +3821,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1467"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:26 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3876,7 +3843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d499682-d5a8-48e7-a837-c911695761f4
+      - 15a0637a-e3f8-4f45-b53c-9c7fb9263561
     status: 200 OK
     code: 200
     duration: ""
@@ -3887,19 +3854,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3909,7 +3876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f06d2a58-4f4f-46b0-aef4-72df8dd5c9ec
+      - e6cb304e-2240-47ba-b6a8-ab8741638871
     status: 200 OK
     code: 200
     duration: ""
@@ -3920,19 +3887,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2620"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3942,7 +3909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0d0c5d1-01d0-4cce-9dc8-100eee4fecae
+      - d0d7cf5e-48a4-4ed2-8005-8d891a63d45a
     status: 200 OK
     code: 200
     duration: ""
@@ -3953,19 +3920,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3975,7 +3942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f1d2960-50fa-4983-9cf7-a2d6d96b0d00
+      - 3306a50a-2469-4af8-8c53-4660a9364a58
     status: 200 OK
     code: 200
     duration: ""
@@ -3986,19 +3953,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "700"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4008,7 +3975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6938649-4514-47aa-af2b-98bd8eca6076
+      - 4af25f54-3b9f-443f-bf52-7a4c0d4110ea
     status: 200 OK
     code: 200
     duration: ""
@@ -4019,19 +3986,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4041,7 +4008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eba493a0-600d-4e9b-b480-29cb08d1420c
+      - 04e2789d-3591-49f0-af4c-dff3bb355344
     status: 200 OK
     code: 200
     duration: ""
@@ -4052,19 +4019,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2620"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:27 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4074,7 +4041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cb77a76-b396-4f9f-a23e-102528b4242a
+      - 4caa878b-01fd-48c5-81d6-47d74ba6fda0
     status: 200 OK
     code: 200
     duration: ""
@@ -4085,19 +4052,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
     method: GET
   response:
-    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "700"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4107,7 +4074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bb8efab-d3c3-48a5-96be-68c6dc2b28d6
+      - 537c9c50-3eee-4f25-b827-4b52e0c7dded
     status: 200 OK
     code: 200
     duration: ""
@@ -4118,85 +4085,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc598348-9cf1-46a2-a46e-ae395d4e59d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 54bec5b0-95a2-427c-ae0f-e76e07615a7d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "222"
+      - "230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4206,7 +4107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aacd14ca-33cc-4fcf-8753-447d294fc57b
+      - 18c9f76b-9fd5-405e-9741-7b4a6230d1f8
     status: 200 OK
     code: 200
     duration: ""
@@ -4217,19 +4118,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "222"
+      - "230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4239,7 +4140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4698ca2-30f2-4e22-ba1b-9772e5297189
+      - 808e89f9-60da-4e64-849e-a2531c0d90e4
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,19 +4151,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901095Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878466983Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4272,7 +4173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b028bb23-7390-481f-a20a-45b851a8a09e
+      - b32d8bcb-99e4-446c-9cf8-cf8d1962ce5a
     status: 200 OK
     code: 200
     duration: ""
@@ -4283,19 +4184,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878467Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:28 GMT
+      - Fri, 10 Nov 2023 13:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4305,7 +4206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad24b1d6-333c-482d-82cb-e3a7c12fdf67
+      - 4674f4e8-a454-4a28-a802-d8b47df979c8
     status: 200 OK
     code: 200
     duration: ""
@@ -4316,19 +4217,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878467Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1515"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:33 GMT
+      - Fri, 10 Nov 2023 13:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +4239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec68cdad-ff6f-4fdd-99d0-14a90707a9fe
+      - 0bec5225-23ca-4ed5-9820-2288fb3925da
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,10 +4250,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e45c9569-a19b-419d-b28e-4620c566dcef","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"37e538b1-848c-431b-9f7f-80357a5f48b2","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4361,7 +4262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:38 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,7 +4272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe26f38d-b8ed-4b36-952e-c1e074bbf4b2
+      - 5bf19426-f460-4309-b1de-5bb0ea7d6f5c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4382,7 +4283,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
     method: DELETE
   response:
     body: ""
@@ -4392,7 +4293,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:39 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4402,7 +4303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce170a23-647c-4196-a7d2-ec527b3d1446
+      - 0c4356e0-ac48-4ae3-94c0-e968be6e6509
     status: 204 No Content
     code: 204
     duration: ""
@@ -4418,16 +4319,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750423899Z","created_at":"2023-11-07T16:25:39.750423899Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760340954Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680640592Z","created_at":"2023-11-10T13:22:22.680640592Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250226Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1446"
+      - "1491"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:39 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4437,7 +4338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a55b18ca-a2da-4757-8fc7-38adef513c64
+      - 44e9dec4-e44d-4cf8-96d5-67b17f478163
     status: 200 OK
     code: 200
     duration: ""
@@ -4448,19 +4349,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:39 GMT
+      - Fri, 10 Nov 2023 13:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4470,7 +4371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a82d147e-79ab-40d6-b39e-0de75337c7e3
+      - e93017b9-d23a-4523-8d37-b97c881da288
     status: 200 OK
     code: 200
     duration: ""
@@ -4481,19 +4382,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:44 GMT
+      - Fri, 10 Nov 2023 13:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4503,7 +4404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa9b2c3d-4c79-4e12-b8d0-ed99251160ec
+      - e4f8799b-e0ed-423a-9c25-6fec3e525e73
     status: 200 OK
     code: 200
     duration: ""
@@ -4514,19 +4415,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:49 GMT
+      - Fri, 10 Nov 2023 13:22:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4536,7 +4437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23d6c560-f893-45e8-b73b-c1af8beb6058
+      - 8e104b9b-d516-4414-a4ac-079d4509491d
     status: 200 OK
     code: 200
     duration: ""
@@ -4547,19 +4448,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:25:55 GMT
+      - Fri, 10 Nov 2023 13:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4569,7 +4470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afef12ab-4d5e-4ff0-9c45-6b6ea7997153
+      - 3750b7cb-450b-496e-a976-5b18351bb55f
     status: 200 OK
     code: 200
     duration: ""
@@ -4580,19 +4481,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:00 GMT
+      - Fri, 10 Nov 2023 13:22:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4602,7 +4503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77ae03a1-37ac-4847-b048-3a9dce38cb35
+      - 6484a103-16d7-4c74-b0f5-57cbe544d579
     status: 200 OK
     code: 200
     duration: ""
@@ -4613,19 +4514,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:05 GMT
+      - Fri, 10 Nov 2023 13:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4635,7 +4536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11ef3b85-bf5b-4099-9857-290e93fce274
+      - f0f009d8-c57c-4d39-8b75-4c53833564d3
     status: 200 OK
     code: 200
     duration: ""
@@ -4646,19 +4547,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:10 GMT
+      - Fri, 10 Nov 2023 13:22:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4668,7 +4569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 836b66e3-8e29-4f01-8238-b91bdd9f1b40
+      - 0a1c9e97-3c8f-4e61-9873-798c7942f8f6
     status: 200 OK
     code: 200
     duration: ""
@@ -4679,19 +4580,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:15 GMT
+      - Fri, 10 Nov 2023 13:22:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4701,7 +4602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be5f35fc-a654-403d-a24c-b15446f86576
+      - 6d652fdc-e4e6-412f-b56d-b5b65eaed7b1
     status: 200 OK
     code: 200
     duration: ""
@@ -4712,19 +4613,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:20 GMT
+      - Fri, 10 Nov 2023 13:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4734,7 +4635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a61416e9-7e6c-44d4-9009-2b58b942eff5
+      - 895200f2-650a-45cf-bd1e-cdfa260f7e58
     status: 200 OK
     code: 200
     duration: ""
@@ -4745,19 +4646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:25 GMT
+      - Fri, 10 Nov 2023 13:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4767,7 +4668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17dd193-c72f-41e7-a244-4b5f60d40050
+      - 7816ab22-7f89-4576-a5ab-f0bfeeb3e77e
     status: 200 OK
     code: 200
     duration: ""
@@ -4778,19 +4679,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:30 GMT
+      - Fri, 10 Nov 2023 13:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4800,7 +4701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31f95cb7-0c05-49bf-95b1-ad768b11a982
+      - 5c03f30e-4cdf-47ee-bd04-88f0b7ec3b8a
     status: 200 OK
     code: 200
     duration: ""
@@ -4811,19 +4712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:35 GMT
+      - Fri, 10 Nov 2023 13:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4833,7 +4734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b373dc7b-eef4-4ded-a556-f839c730dd95
+      - b630a1b0-76da-4c50-a969-9d3774ffad46
     status: 200 OK
     code: 200
     duration: ""
@@ -4844,19 +4745,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:40 GMT
+      - Fri, 10 Nov 2023 13:23:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4866,7 +4767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5c518ee-79c2-4653-8a81-8621a5b20528
+      - 91a3222a-eb6b-42b1-b84d-dae61ca7e16d
     status: 200 OK
     code: 200
     duration: ""
@@ -4877,19 +4778,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:45 GMT
+      - Fri, 10 Nov 2023 13:23:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4899,7 +4800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd73925d-fc93-44aa-a35a-2d91e128b74c
+      - 84c3239f-9e26-41e9-877a-ee6f589a302b
     status: 200 OK
     code: 200
     duration: ""
@@ -4910,19 +4811,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:50 GMT
+      - Fri, 10 Nov 2023 13:23:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4932,7 +4833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 199a2fce-62fa-45be-8b04-55d38dfad155
+      - e3df24bd-2680-4bf1-9375-090177a1361e
     status: 200 OK
     code: 200
     duration: ""
@@ -4943,19 +4844,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:26:55 GMT
+      - Fri, 10 Nov 2023 13:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4965,7 +4866,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70601d34-3c35-47e5-9987-754a9efbfaec
+      - 976b568b-198b-47b7-ac8a-e85f63a35818
     status: 200 OK
     code: 200
     duration: ""
@@ -4976,19 +4877,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:00 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4998,7 +4899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e9f7e4-6b49-4c02-9a64-4c680b39a7c2
+      - 31ba0c13-7b74-433f-af67-930418d668a8
     status: 200 OK
     code: 200
     duration: ""
@@ -5009,19 +4910,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:00 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5031,7 +4932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fe72da2-8e23-48f5-8427-9ac0d144f338
+      - 7df81a85-8c7f-4398-9e51-f90b02f55976
     status: 200 OK
     code: 200
     duration: ""
@@ -5042,19 +4943,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:00 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5064,7 +4965,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5546e6de-2c0a-4211-86cc-237eeab04dce
+      - 09dd7158-6b00-416f-9cce-8f98be411118
     status: 200 OK
     code: 200
     duration: ""
@@ -5075,19 +4976,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:00 GMT
+      - Fri, 10 Nov 2023 13:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5097,7 +4998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ee7abd4-eb9c-490a-96c0-c6eacc032c87
+      - 3476c08d-844e-4775-9a7e-d688fe81a8cf
     status: 200 OK
     code: 200
     duration: ""
@@ -5108,19 +5009,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:01 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5130,7 +5031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b967faf6-b44c-441c-b8b3-6edcc8ceae87
+      - cecab382-2b65-46bb-9eea-1276613249d5
     status: 200 OK
     code: 200
     duration: ""
@@ -5141,19 +5042,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:01 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5163,7 +5064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aafcec44-dd3c-4b58-8bcf-b36622a4cd38
+      - 575c319f-eb5a-451d-96bc-a33abf23c262
     status: 200 OK
     code: 200
     duration: ""
@@ -5174,19 +5075,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:01 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5196,7 +5097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c92e5eef-309c-4075-99e3-8d8b718a7065
+      - d74c56ca-ea95-4af8-881b-a653d16ff58d
     status: 200 OK
     code: 200
     duration: ""
@@ -5207,19 +5108,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:01 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5229,7 +5130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9477d43-8f9e-4dc7-80af-02872899740e
+      - 1f4018e4-0520-4225-bcfd-3483b6f3e833
     status: 200 OK
     code: 200
     duration: ""
@@ -5240,52 +5141,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
-    method: GET
-  response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "413"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:27:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 688a3500-73fb-480a-9f6e-735d0aa6f580
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "413"
+      - "429"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:02 GMT
+      - Fri, 10 Nov 2023 13:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5295,7 +5163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa1a465-e9ea-4917-83f0-1191c27aaee9
+      - 558c1407-84b2-49b0-a749-633a34b8c1e5
     status: 200 OK
     code: 200
     duration: ""
@@ -5306,19 +5174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "413"
+      - "429"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:02 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5328,7 +5196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6d8ba82-06fb-421b-9ca4-7459e52313bd
+      - ec0ea766-f0bc-4130-9a75-91b4895d3dc2
     status: 200 OK
     code: 200
     duration: ""
@@ -5339,19 +5207,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "1434"
+      - "429"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:02 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5361,7 +5229,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd62efb0-eb3e-4b60-a942-21d47c3fb079
+      - faaa3552-f900-4933-8661-f14f712f727c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1479"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:23:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f2229bed-3dea-433d-9677-888887de90d5
     status: 200 OK
     code: 200
     duration: ""
@@ -5374,19 +5275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930080903Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001137647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617937557Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801920680Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1443"
+      - "1488"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:03 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5396,7 +5297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87cd14f9-06b0-4da9-b85d-52d166f0f070
+      - 263ee2e1-fcac-4bef-b50d-7cc37f17fbd7
     status: 200 OK
     code: 200
     duration: ""
@@ -5407,19 +5308,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:03 GMT
+      - Fri, 10 Nov 2023 13:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5429,7 +5330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 270a57c0-9dda-4a77-ac4d-31948661d5aa
+      - c538c4bc-b37f-4e7d-ae92-66c286e8f135
     status: 200 OK
     code: 200
     duration: ""
@@ -5440,19 +5341,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:08 GMT
+      - Fri, 10 Nov 2023 13:23:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5462,7 +5363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88881f72-9d42-44c0-8727-4ae41105fe36
+      - 6cabfa20-0ea1-41d5-b02d-850025757d74
     status: 200 OK
     code: 200
     duration: ""
@@ -5473,19 +5374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:13 GMT
+      - Fri, 10 Nov 2023 13:23:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5495,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d827202-1295-49d5-80fc-2b02afd4e0a4
+      - b4e077cc-5588-4d66-87e7-7806a408172b
     status: 200 OK
     code: 200
     duration: ""
@@ -5506,19 +5407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:18 GMT
+      - Fri, 10 Nov 2023 13:24:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5528,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba68025-0506-4bfa-b853-c446aa8e4d0d
+      - 5c04aafa-ca6e-4fd5-854d-6e01053ce2e4
     status: 200 OK
     code: 200
     duration: ""
@@ -5539,19 +5440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:23 GMT
+      - Fri, 10 Nov 2023 13:24:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5561,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a09d50ce-2a92-4db8-9269-6fda5c2580e6
+      - 66c5886a-4982-49b1-b83b-071cc7958d01
     status: 200 OK
     code: 200
     duration: ""
@@ -5572,19 +5473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:28 GMT
+      - Fri, 10 Nov 2023 13:24:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5594,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8d7ab5b-1467-4979-813a-a162da9f1467
+      - eea3787d-d613-4bbb-a2d5-673bff2a49e7
     status: 200 OK
     code: 200
     duration: ""
@@ -5605,19 +5506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:33 GMT
+      - Fri, 10 Nov 2023 13:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5627,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd91e50c-6a94-41ea-b0b1-4168cf22f0c8
+      - c788d958-6460-4d43-9a5e-190d6b1bc64c
     status: 200 OK
     code: 200
     duration: ""
@@ -5638,19 +5539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:38 GMT
+      - Fri, 10 Nov 2023 13:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5660,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfd9d0a6-0ab4-4fa6-9069-d5acb81ac1d1
+      - 6ab76677-633f-4a5c-83b8-71b6581132f7
     status: 200 OK
     code: 200
     duration: ""
@@ -5671,19 +5572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:43 GMT
+      - Fri, 10 Nov 2023 13:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b74527ed-7dd9-40dc-81de-7b4165291c75
+      - 29cc261c-5536-4e6a-9cb7-8b5a4293918a
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,19 +5605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:48 GMT
+      - Fri, 10 Nov 2023 13:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1d74e08-60a7-4847-96f8-d873e977b6b6
+      - 6ff6c802-b5af-43bc-bcbf-419e15fdc092
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,19 +5638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:53 GMT
+      - Fri, 10 Nov 2023 13:24:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c3bd1f8-a717-4c3c-9e12-5f32302da553
+      - c1632a06-2743-4b8a-a0cf-d6b3ddafbf70
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,19 +5671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:27:58 GMT
+      - Fri, 10 Nov 2023 13:24:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33637e42-624d-4be0-9e76-baf55fa4afa6
+      - aec59cb5-39ca-427c-867b-768cacc3230e
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,19 +5704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:03 GMT
+      - Fri, 10 Nov 2023 13:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 031d8e2a-3905-4175-af84-49c2f0103a01
+      - b8d1eb70-4818-4611-a0c6-7f1bffa84d7b
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,19 +5737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:08 GMT
+      - Fri, 10 Nov 2023 13:24:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 553a2d7b-34eb-4f44-9699-7054c1ba716f
+      - d9536c68-a34d-46b3-aa5a-a8e5617f77c1
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,19 +5770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:13 GMT
+      - Fri, 10 Nov 2023 13:24:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86fa23b6-e9a0-46a6-8f4a-2dbfc0ab8ab6
+      - 591d6eca-7ee7-48d6-b136-35ce07408749
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,19 +5803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:18 GMT
+      - Fri, 10 Nov 2023 13:25:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5924,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6e3937a-807f-4803-98eb-dde3283da6c8
+      - 59b7c1f7-48a2-437c-b72b-5a4bccfeda66
     status: 200 OK
     code: 200
     duration: ""
@@ -5935,19 +5836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:23 GMT
+      - Fri, 10 Nov 2023 13:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5957,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 697728be-b0bf-4ae3-be2c-c976cc81e3c5
+      - 3b557da2-f45b-4eff-a59c-a6a03787d77a
     status: 200 OK
     code: 200
     duration: ""
@@ -5968,19 +5869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:28.525155Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:29 GMT
+      - Fri, 10 Nov 2023 13:25:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5990,7 +5891,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4367150-7572-4ec8-a635-a69944fb8afa
+      - ed721fa8-9ff2-4711-b9f3-18e5b992fcb8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8b85a33-db17-4984-a200-cd2a0e63442d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:18.338690Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1479"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:25:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5edae30-4668-4cc3-9fa3-877e8707dc38
     status: 200 OK
     code: 200
     duration: ""
@@ -6003,19 +5970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115275818Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:29 GMT
+      - Fri, 10 Nov 2023 13:25:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6025,7 +5992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97ee7bd7-7584-4a90-aa7c-9b2e5553ef07
+      - b1d5d04b-2963-4ea3-8c58-6ac1c935be14
     status: 200 OK
     code: 200
     duration: ""
@@ -6036,19 +6003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:29 GMT
+      - Fri, 10 Nov 2023 13:25:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6058,7 +6025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf2a645b-fdbb-47b3-8a91-af18cf0322f0
+      - ae6764f0-c4f2-4800-a1b6-468b264e92d8
     status: 200 OK
     code: 200
     duration: ""
@@ -6069,19 +6036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:34 GMT
+      - Fri, 10 Nov 2023 13:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6091,7 +6058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 883b56b4-2808-4166-a5bb-a13a3eaf698c
+      - 08ed3b36-978b-4866-a339-5f16f5f6ffa3
     status: 200 OK
     code: 200
     duration: ""
@@ -6102,19 +6069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:39 GMT
+      - Fri, 10 Nov 2023 13:25:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6124,7 +6091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 770ca229-b970-4bc0-bf96-526f41cbb352
+      - 2c4534c4-68ce-40cb-924b-7f630c649f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -6135,19 +6102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:44 GMT
+      - Fri, 10 Nov 2023 13:25:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6157,7 +6124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba055f4e-3ea4-4c08-94c9-afc72fc0f989
+      - 057c935f-67a2-4cc1-a93f-c8c5b34a0b27
     status: 200 OK
     code: 200
     duration: ""
@@ -6168,19 +6135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:49 GMT
+      - Fri, 10 Nov 2023 13:25:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6190,7 +6157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 114cd0c3-ec01-4787-b160-c5bce9fc8bd7
+      - 1313c499-2182-460b-b300-b52945c1c7b1
     status: 200 OK
     code: 200
     duration: ""
@@ -6201,19 +6168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:54 GMT
+      - Fri, 10 Nov 2023 13:25:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6223,7 +6190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 216a4875-e80a-4e7a-b192-c4012bbd7fe4
+      - 7ea550a1-c874-4409-a645-5616b0d2287c
     status: 200 OK
     code: 200
     duration: ""
@@ -6234,19 +6201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:28:59 GMT
+      - Fri, 10 Nov 2023 13:25:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6256,7 +6223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a54b73ee-9c9d-49c2-aefc-090bef96673a
+      - 21c5e814-2e13-4c5b-b7da-1d1b4c749afd
     status: 200 OK
     code: 200
     duration: ""
@@ -6267,19 +6234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:04 GMT
+      - Fri, 10 Nov 2023 13:25:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6289,7 +6256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a3876d7-f8c9-4fca-951a-1603c0058efb
+      - 79239230-e672-45cb-99d2-14eb7ada3a92
     status: 200 OK
     code: 200
     duration: ""
@@ -6300,19 +6267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:09 GMT
+      - Fri, 10 Nov 2023 13:25:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6322,7 +6289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6973119-feb4-401a-8488-29216919c610
+      - 35f8b453-0cab-41d7-9942-3ce778a7644f
     status: 200 OK
     code: 200
     duration: ""
@@ -6333,19 +6300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1434"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:14 GMT
+      - Fri, 10 Nov 2023 13:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6355,7 +6322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9abd487d-e3e8-4b05-8383-3690cabc26d5
+      - 2be67cd5-7083-4e77-8d36-bb06fa020559
     status: 200 OK
     code: 200
     duration: ""
@@ -6366,19 +6333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:14 GMT
+      - Fri, 10 Nov 2023 13:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6388,7 +6355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a61ab3-6d9e-4c9c-8994-bcb60dffeaa0
+      - 6a7d06f0-5533-4623-8f02-a5b335996f17
     status: 200 OK
     code: 200
     duration: ""
@@ -6399,19 +6366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2620"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:14 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6421,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c913685b-e0a1-446e-846e-d55fefe68e61
+      - f99c004d-762e-4ac6-bdea-4ed51978e803
     status: 200 OK
     code: 200
     duration: ""
@@ -6432,19 +6399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1434"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:14 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6454,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 760e4051-979f-4982-9a72-83364288bc30
+      - 44575731-9707-4836-950f-d5158a4cd408
     status: 200 OK
     code: 200
     duration: ""
@@ -6465,19 +6432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:15 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6487,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95851621-c98c-4428-b7b3-95c09bf0c041
+      - aee19847-51f7-4266-abc2-69babfe44d73
     status: 200 OK
     code: 200
     duration: ""
@@ -6498,19 +6465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:15 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6520,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8d350b5-2d2d-4e20-93aa-96af3a89cfc7
+      - ba0e276a-0cf0-4025-991b-657300899fb6
     status: 200 OK
     code: 200
     duration: ""
@@ -6531,85 +6498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1434"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:29:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae27ee1a-4ef8-43cc-8917-49262d3b54a5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 Nov 2023 16:29:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 22a1fd86-0b9b-4a1e-a7b8-3d926f8f7d5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "225"
+      - "233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:17 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6619,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e95f3549-1146-4a8a-8691-8c4b2e039044
+      - 2ebde85d-cd18-4583-a665-f7c88784b702
     status: 200 OK
     code: 200
     duration: ""
@@ -6630,19 +6531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "225"
+      - "233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:17 GMT
+      - Fri, 10 Nov 2023 13:26:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6652,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2b9d65c-8c25-4138-8b01-5f7fc83515d2
+      - db0b259f-7cb0-4822-85fd-045fd25b314b
     status: 200 OK
     code: 200
     duration: ""
@@ -6663,19 +6564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148808659Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229198961Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1440"
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:18 GMT
+      - Fri, 10 Nov 2023 13:26:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +6586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42eef2df-c8b3-468e-8f67-71d40dbe33b4
+      - 7f05f8c7-c6c7-4051-a9d8-4e8b35b65317
     status: 200 OK
     code: 200
     duration: ""
@@ -6696,19 +6597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148809Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229199Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:18 GMT
+      - Fri, 10 Nov 2023 13:26:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6718,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3be81e67-ba7e-4712-8bd8-1692f44393aa
+      - 178d1a5e-e05e-4aeb-9a6e-9e52f93159e2
     status: 200 OK
     code: 200
     duration: ""
@@ -6729,19 +6630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148809Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229199Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1437"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:23 GMT
+      - Fri, 10 Nov 2023 13:26:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6751,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73685f9d-6c7b-4f84-870a-1311fb03be83
+      - af4e3a79-22ea-422d-8106-f062516d10b3
     status: 200 OK
     code: 200
     duration: ""
@@ -6762,10 +6663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6774,7 +6675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:28 GMT
+      - Fri, 10 Nov 2023 13:26:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6784,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69e6f546-eb61-4d47-80b9-2e2ef6a8eec7
+      - 9a9694d6-b828-477d-861b-231c4c342a88
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6800,16 +6701,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193112Z","created_at":"2023-11-07T16:29:28.473193112Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123049Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548612820Z","created_at":"2023-11-10T13:26:12.548612820Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566358602Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1434"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:28 GMT
+      - Fri, 10 Nov 2023 13:26:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6819,7 +6720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712da4b9-1207-4608-8193-5cb1193ed92f
+      - fcc8b7fd-3ba8-4396-af77-3625c77cbcf9
     status: 200 OK
     code: 200
     duration: ""
@@ -6830,19 +6731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:28 GMT
+      - Fri, 10 Nov 2023 13:26:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6852,7 +6753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4596fc05-38bb-41a4-867c-dbe0245dbd7b
+      - 79cadd68-1a6b-4ada-8422-f84c0847e122
     status: 200 OK
     code: 200
     duration: ""
@@ -6863,19 +6764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:33 GMT
+      - Fri, 10 Nov 2023 13:26:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6885,7 +6786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5341cda-8233-44a7-80ce-290228e175b8
+      - 59b0cf29-cc60-4c6f-8622-8a15eb3b9c20
     status: 200 OK
     code: 200
     duration: ""
@@ -6896,19 +6797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:38 GMT
+      - Fri, 10 Nov 2023 13:26:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6918,7 +6819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cbc67ce-0e4a-4a4f-9109-b87ff739129d
+      - 37ab03f7-5b36-43b4-8a59-f63f1f2db1e4
     status: 200 OK
     code: 200
     duration: ""
@@ -6929,19 +6830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:43 GMT
+      - Fri, 10 Nov 2023 13:26:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6951,7 +6852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be3cd6a0-2582-40c2-95da-5518fe22038d
+      - a71f9392-ace9-4970-b6ba-0486e611584f
     status: 200 OK
     code: 200
     duration: ""
@@ -6962,19 +6863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:48 GMT
+      - Fri, 10 Nov 2023 13:26:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6984,7 +6885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a818c2ef-eb6d-4abc-898a-9bd44d188dde
+      - e3dc49c2-7e92-4cf8-a242-e282f0a2af0a
     status: 200 OK
     code: 200
     duration: ""
@@ -6995,19 +6896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:53 GMT
+      - Fri, 10 Nov 2023 13:26:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7017,7 +6918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c83d2199-e808-4e3d-a790-54b199bdd459
+      - daf03522-aa8c-42c8-8673-078cd4c5ee22
     status: 200 OK
     code: 200
     duration: ""
@@ -7028,19 +6929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:29:58 GMT
+      - Fri, 10 Nov 2023 13:26:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7050,7 +6951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcda8eb3-a28e-4e90-aa35-d20adb197875
+      - f07513c6-2747-4473-8dcd-3e65c8e65ed6
     status: 200 OK
     code: 200
     duration: ""
@@ -7061,19 +6962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:03 GMT
+      - Fri, 10 Nov 2023 13:26:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7083,7 +6984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a729333-a936-40bb-964e-9cf1af6a1942
+      - e0d035cb-3001-406c-b09d-8ea3eefefbd0
     status: 200 OK
     code: 200
     duration: ""
@@ -7094,19 +6995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:08 GMT
+      - Fri, 10 Nov 2023 13:26:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7116,7 +7017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 217753dd-36f1-4cda-be18-cd491bac94de
+      - 8eaf1563-aa06-47d7-963b-5549c8303c13
     status: 200 OK
     code: 200
     duration: ""
@@ -7127,19 +7028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:14 GMT
+      - Fri, 10 Nov 2023 13:26:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7149,7 +7050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73c9f8aa-48d0-4c28-8499-86907af66dd1
+      - 6bc5c18f-8027-4cfa-832c-12dbccda230c
     status: 200 OK
     code: 200
     duration: ""
@@ -7160,19 +7061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:19 GMT
+      - Fri, 10 Nov 2023 13:27:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7182,7 +7083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90ba11ba-53ae-454a-bd1e-f1550da39bb3
+      - 43dcc545-cd03-4c23-b998-359d35f42161
     status: 200 OK
     code: 200
     duration: ""
@@ -7193,19 +7094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:24 GMT
+      - Fri, 10 Nov 2023 13:27:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7215,7 +7116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a6089d8-ccce-464f-85a8-e9120dc10495
+      - 182943d7-46a5-499e-a34a-b075a46fe11a
     status: 200 OK
     code: 200
     duration: ""
@@ -7226,19 +7127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:29 GMT
+      - Fri, 10 Nov 2023 13:27:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7248,7 +7149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f959c79e-3c50-45b1-a943-8ad315a5cd8c
+      - d4588aeb-4e21-4936-821f-62865c9222f9
     status: 200 OK
     code: 200
     duration: ""
@@ -7259,19 +7160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:34 GMT
+      - Fri, 10 Nov 2023 13:27:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7281,7 +7182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 577a0b02-13f3-403c-bc3f-87900531157c
+      - fc00d16a-e26f-44ec-9bb5-9e88004895cf
     status: 200 OK
     code: 200
     duration: ""
@@ -7292,19 +7193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1422"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7314,7 +7215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bdea557-aa27-453c-b272-6b4a283a8f7c
+      - 2c3d0810-e944-40f0-9508-836e633940b0
     status: 200 OK
     code: 200
     duration: ""
@@ -7325,19 +7226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1422"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7347,7 +7248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cba6bf6-a53a-42e5-8941-50ec7c1bfab5
+      - 65da0008-339c-4a8f-a97e-a5d54d51c7c5
     status: 200 OK
     code: 200
     duration: ""
@@ -7358,19 +7259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3ByZWsxR2IxaEVWRTE2VFZSRmQwNXFSVEpOYW10NlRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG10UENrNTVjVEIwYmxSVU9VMUpjR2RXUkZkdVIzRTBhVU5EUTJaMmNtMVpabGd2YkRsMllrTnRkVzFhUzFSMFNubzJTMGhVWjI5TVNXTlBlVXBVU2xWdmNGb0thV3RXUzA1WlNGUklLMU5qVGs1cGVrTk1PSGsyYVZoYVRTOXZSa281VURSUGRrTjZNVVpQVEhBNGNYRmtNVVE1YldSTlkyUkdVM05LVW5sVVdXZGFSZ3BFUzJneVIyNVpTR0l2YVVWUWFraFdlRXRwVW5SSmVqWXZaR1JQYjJwMVZYSlNOWE5FUVZCeGMzTnlkMUZpVGpWQ0syWlVORmN2ZEhKNFYyaG1UbmR1Q2xkSU9HeFBNeTlYTW1WSmQwdE9OV2MwWVM5RmFtMTVZa1JSYW5KWVowWlNSbkJCV0U1dmJqQjBVRzgxYjNWU01raHBiR0l3UVVKeVZ6QldjVEYxTTI0S2VuUllTRmxWYW5vclpFbFRSRWN5VHpCWFJrbG9lWGM1VXlzeVFXVm5ORWRvUjB3MVdXdHJSV1pDTVZOaWVFVnhWa3BxZUVkUGVETnNkazB6VjBkb1J3cHdNMjA1UTNCS1NVbERWR1ppUldWcVVIaEZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlFMeThyY25JeGFESkZNSEIzWjBabmRVeFZXbUV4Y1U4NWFFcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNSV1p3V0RSNlpuSkRXbnBuWW5oa0x6TlFjV2h5UzNoWVpXcDJXVkZCTWtKcFYwUllhbU5zYlRKd1JFODJOa1l6ZVFvck4ydHFOa2RwZW0xS1lUSjBPR1owVFUxTGVXTlZVbXRYU25OQ1pVRjNUM0EzUkVKVlVrNVllbUV6WkZOWE5UaHFjakp1WVhocFRGSlNWVXhxYkdReUNtNWxlbG92ZWtGSGNEaFJORmN4WVdKSU9FWk5iVlZDV2tOVWN6TmlkRkJRZUVFdldDOXNlRXQyZVVkUlJURjNWa2huVkZWcmRWbHJXRlJ1VkRaWU5FY0tTMjlqYWtoelRucE9WSGxMU2poQlZWVnJRVkZVWlZwUlYzcExhVUppYldaalRteDVSRUowTWtkc1pVSlVhMG81TjBNMU9IQXZlV1EzTVZvNVkxbDFWd280VnpRNE5GcGFXbVpPYWxabWExY3hjMnd6TjJaeFF5dGFVMDE0VEdkWVFsUjZia2hOYTNST1RHSnZUM0ZMTVZKdE1EVnpZVU5hTUVsaVFYWlFaREIzQ2t4cVFUWXpNRTFST1hWNFVXOHpkVlIxWVZwRlNWaFdhRW8zUWs5SFlVbGlkMjkyVUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y1MzRlYmVmLTNmZWUtNDAzOC05ZWFiLTYxNWI1NjZjNGU3OC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcmszUm56OHpZRnNOVVhvTUpxVlRWZU0zaDhPc3oxSmlDU0lhb1dzY0Rib0pmMUN4T0VGRjRYUw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BaZUUweGIxaEVWRTE2VFZSRmQwOVVSWHBOYWxsNFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGtOb0NrSjNTVTVUUVVsRFlUVlhOelJrTlVSQlIwWXhjVmRrVTBGalVUbHFaR1l5V0V4bk5tbHlWVEptTTJKSU5WVlpOMll6Y1RoS1NWSk5Ra056T0RWMmJGVUtNazlIVDFOdFFrSlJNMEZ1WW05TFpGWldiMU55Y0VsUlprcHhjMnhuV1ZGRlQyZ3dVbTVFY2tSdlptWlJhV0pTWVRNNVIwa3hOVEJ5T1ZOMlJrWTJUQXA0U2xoM1YyYzRZbGRpUzBWVkt5dEtTVUpGZVZnMk0zSnJVMlEyTTFod1RGUndWMUozVkdFclMzQk1NWEZrZGxsdmNUa3ZhM2Q2VUZONVRGaFplRWhHQ2xsTE9UbEVXVEYyYVhCNGNEa3haVmR1TXpoNGQyRjJUakUzWTBad1JqTk5NVEpYYnpjNWVFaGxSV05LWTJWSWVFZzBiRWhGTW5sMmMxQmlibVF2U0hZS01rbDVVVVEzVm10blNWTkxlRkF3U213dlZVZFpOMWQ0VEdOM2IwOTJXSFpETWs5SFVqaENVRXBCUkhkb2VrdEViRXhHYW04MVlrbzNiVzVWZGxGR1JRcEdhQzg0V0VGRlNFNHlNVkJCV0hCRFR6RXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpVVGg0TVZoVWFYZDVRVkkyUVdsTWRTOTJXRmhxZHpGTVRrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWSE5LTW14TlEwbHNNbmRIY0RWR1drWktLM2RKTUVnM1lrTkVlWHBrVW0xS1JISlhTMU5OT0ZRMk9VeG9iRTFLU1FwMFRVWjNOelJuVlV0NWQzVnRaRUkyTldaT01rOWhSRFZzU25OblZHdzVORFowUmtWclYxVldNMnB0YUdjeUwxQk9jM3BFUlZsSVFtVk1NRmxJSzNadkNrcGxOMHBPYVVkamEyTjFXSGRYYkhrMlVUZG5ha1pJTUZoQ2QzaG5jRFJHYUc5M2F5OVJXVFo0VkRGR2NXWnRaVlk0ZG01R1pqTkNUa2hqT0hSc1FVSUthSGRtU2tkMU0yMVlNMVoxVTB0TmFVNURSbXB1UmxsdlIwNXJMemx6YkhBd1VHTjBPVkY0VVdWR2JWUnlkVXRWWkU1WlQzTlZlRGxDZEVab1YyMVVkUW96V2xkMVVrbFpiM0pIY0drd2VqaExRbEpuYjJJeFZscHJlbVZIU3pOc1puWXdMMVo1Y0VVMk1EZHhWa3hHU1VaVloxTmpNbUYzV0ZCeE1FbEdZVloyQ21ob2JWVXpWMlZTYUZoRlNUUjNTMlEyZGtsa01WSlhWeTloVDJobVIzUkJaWEJ4YXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzEyZDdmYjUxLTcxNGQtNDA3OC05ZTRkLWZhODAyOWU0MWUwZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1QWJDVjFnSEl4RFk5UXZKUGNWVGozdEczVWtVa0pDVjduVDZxREwxdnU1bE1TY1JGcVRTUkNRQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adf41e0b-1b4e-43db-9f0e-d54de9219562
+      - 81411bde-bf46-494c-83b9-60a64082923f
     status: 200 OK
     code: 200
     duration: ""
@@ -7391,19 +7292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1422"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 410931b9-e7ed-4148-a9a2-71821332f4eb
+      - 464aa79d-78e0-4d59-8225-70f1fd0c7311
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,19 +7325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1422"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85c39ced-d2a5-4e0a-9da3-8218bb7e4fd6
+      - 76a6dcff-ee5a-4d6e-9749-048891bed2af
     status: 200 OK
     code: 200
     duration: ""
@@ -7457,19 +7358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3ByZWsxR2IxaEVWRTE2VFZSRmQwNXFSVEpOYW10NlRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG10UENrNTVjVEIwYmxSVU9VMUpjR2RXUkZkdVIzRTBhVU5EUTJaMmNtMVpabGd2YkRsMllrTnRkVzFhUzFSMFNubzJTMGhVWjI5TVNXTlBlVXBVU2xWdmNGb0thV3RXUzA1WlNGUklLMU5qVGs1cGVrTk1PSGsyYVZoYVRTOXZSa281VURSUGRrTjZNVVpQVEhBNGNYRmtNVVE1YldSTlkyUkdVM05LVW5sVVdXZGFSZ3BFUzJneVIyNVpTR0l2YVVWUWFraFdlRXRwVW5SSmVqWXZaR1JQYjJwMVZYSlNOWE5FUVZCeGMzTnlkMUZpVGpWQ0syWlVORmN2ZEhKNFYyaG1UbmR1Q2xkSU9HeFBNeTlYTW1WSmQwdE9OV2MwWVM5RmFtMTVZa1JSYW5KWVowWlNSbkJCV0U1dmJqQjBVRzgxYjNWU01raHBiR0l3UVVKeVZ6QldjVEYxTTI0S2VuUllTRmxWYW5vclpFbFRSRWN5VHpCWFJrbG9lWGM1VXlzeVFXVm5ORWRvUjB3MVdXdHJSV1pDTVZOaWVFVnhWa3BxZUVkUGVETnNkazB6VjBkb1J3cHdNMjA1UTNCS1NVbERWR1ppUldWcVVIaEZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlFMeThyY25JeGFESkZNSEIzWjBabmRVeFZXbUV4Y1U4NWFFcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNSV1p3V0RSNlpuSkRXbnBuWW5oa0x6TlFjV2h5UzNoWVpXcDJXVkZCTWtKcFYwUllhbU5zYlRKd1JFODJOa1l6ZVFvck4ydHFOa2RwZW0xS1lUSjBPR1owVFUxTGVXTlZVbXRYU25OQ1pVRjNUM0EzUkVKVlVrNVllbUV6WkZOWE5UaHFjakp1WVhocFRGSlNWVXhxYkdReUNtNWxlbG92ZWtGSGNEaFJORmN4WVdKSU9FWk5iVlZDV2tOVWN6TmlkRkJRZUVFdldDOXNlRXQyZVVkUlJURjNWa2huVkZWcmRWbHJXRlJ1VkRaWU5FY0tTMjlqYWtoelRucE9WSGxMU2poQlZWVnJRVkZVWlZwUlYzcExhVUppYldaalRteDVSRUowTWtkc1pVSlVhMG81TjBNMU9IQXZlV1EzTVZvNVkxbDFWd280VnpRNE5GcGFXbVpPYWxabWExY3hjMnd6TjJaeFF5dGFVMDE0VEdkWVFsUjZia2hOYTNST1RHSnZUM0ZMTVZKdE1EVnpZVU5hTUVsaVFYWlFaREIzQ2t4cVFUWXpNRTFST1hWNFVXOHpkVlIxWVZwRlNWaFdhRW8zUWs5SFlVbGlkMjkyVUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y1MzRlYmVmLTNmZWUtNDAzOC05ZWFiLTYxNWI1NjZjNGU3OC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcmszUm56OHpZRnNOVVhvTUpxVlRWZU0zaDhPc3oxSmlDU0lhb1dzY0Rib0pmMUN4T0VGRjRYUw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BaZUUweGIxaEVWRTE2VFZSRmQwOVVSWHBOYWxsNFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGtOb0NrSjNTVTVUUVVsRFlUVlhOelJrTlVSQlIwWXhjVmRrVTBGalVUbHFaR1l5V0V4bk5tbHlWVEptTTJKSU5WVlpOMll6Y1RoS1NWSk5Ra056T0RWMmJGVUtNazlIVDFOdFFrSlJNMEZ1WW05TFpGWldiMU55Y0VsUlprcHhjMnhuV1ZGRlQyZ3dVbTVFY2tSdlptWlJhV0pTWVRNNVIwa3hOVEJ5T1ZOMlJrWTJUQXA0U2xoM1YyYzRZbGRpUzBWVkt5dEtTVUpGZVZnMk0zSnJVMlEyTTFod1RGUndWMUozVkdFclMzQk1NWEZrZGxsdmNUa3ZhM2Q2VUZONVRGaFplRWhHQ2xsTE9UbEVXVEYyYVhCNGNEa3haVmR1TXpoNGQyRjJUakUzWTBad1JqTk5NVEpYYnpjNWVFaGxSV05LWTJWSWVFZzBiRWhGTW5sMmMxQmlibVF2U0hZS01rbDVVVVEzVm10blNWTkxlRkF3U213dlZVZFpOMWQ0VEdOM2IwOTJXSFpETWs5SFVqaENVRXBCUkhkb2VrdEViRXhHYW04MVlrbzNiVzVWZGxGR1JRcEdhQzg0V0VGRlNFNHlNVkJCV0hCRFR6RXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpVVGg0TVZoVWFYZDVRVkkyUVdsTWRTOTJXRmhxZHpGTVRrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWSE5LTW14TlEwbHNNbmRIY0RWR1drWktLM2RKTUVnM1lrTkVlWHBrVW0xS1JISlhTMU5OT0ZRMk9VeG9iRTFLU1FwMFRVWjNOelJuVlV0NWQzVnRaRUkyTldaT01rOWhSRFZzU25OblZHdzVORFowUmtWclYxVldNMnB0YUdjeUwxQk9jM3BFUlZsSVFtVk1NRmxJSzNadkNrcGxOMHBPYVVkamEyTjFXSGRYYkhrMlVUZG5ha1pJTUZoQ2QzaG5jRFJHYUc5M2F5OVJXVFo0VkRGR2NXWnRaVlk0ZG01R1pqTkNUa2hqT0hSc1FVSUthSGRtU2tkMU0yMVlNMVoxVTB0TmFVNURSbXB1UmxsdlIwNXJMemx6YkhBd1VHTjBPVkY0VVdWR2JWUnlkVXRWWkU1WlQzTlZlRGxDZEVab1YyMVVkUW96V2xkMVVrbFpiM0pIY0drd2VqaExRbEpuYjJJeFZscHJlbVZIU3pOc1puWXdMMVo1Y0VVMk1EZHhWa3hHU1VaVloxTmpNbUYzV0ZCeE1FbEdZVloyQ21ob2JWVXpWMlZTYUZoRlNUUjNTMlEyZGtsa01WSlhWeTloVDJobVIzUkJaWEJ4YXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzEyZDdmYjUxLTcxNGQtNDA3OC05ZTRkLWZhODAyOWU0MWUwZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1QWJDVjFnSEl4RFk5UXZKUGNWVGozdEczVWtVa0pDVjduVDZxREwxdnU1bE1TY1JGcVRTUkNRQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2620"
+      - "2622"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:39 GMT
+      - Fri, 10 Nov 2023 13:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7479,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2068a473-5a11-4d5b-8785-4640504ba5cc
+      - 16b3435d-5173-4703-87ce-554151fa5da3
     status: 200 OK
     code: 200
     duration: ""
@@ -7490,19 +7391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:40.229640115Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999031Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1428"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:40 GMT
+      - Fri, 10 Nov 2023 13:27:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0047535-320b-473c-9542-8d16c49083d9
+      - 7afc61be-74b2-43b7-8d51-af58938679e0
     status: 200 OK
     code: 200
     duration: ""
@@ -7523,19 +7424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:40.229640Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1425"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:40 GMT
+      - Fri, 10 Nov 2023 13:27:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7545,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a442c09-f1e1-4bf1-872c-e9616fea87be
+      - 66a8631f-8a03-4553-ad05-6bb3f496e8e1
     status: 200 OK
     code: 200
     duration: ""
@@ -7556,10 +7457,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f534ebef-3fee-4038-9eab-615b566c4e78","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Nov 2023 13:27:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6692e21f-77b3-49ae-94f0-2403b2d1f868
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7568,7 +7502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:45 GMT
+      - Fri, 10 Nov 2023 13:27:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7578,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 842d216f-946a-4abf-8984-bb9a86d0423c
+      - 54b16392-6ed9-41cf-a7c2-c3e2c6da1edc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7589,10 +7523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f534ebef-3fee-4038-9eab-615b566c4e78","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7601,7 +7535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 07 Nov 2023 16:30:45 GMT
+      - Fri, 10 Nov 2023 13:27:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7611,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2b3cef8-d34e-499c-8b96-f630bc860e1b
+      - 9c6fa271-7f63-4ade-a4f3-0a8a987e853c
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
In an attempt to fix the random errors in the K8s nightly tests, listing every resource that was used in each test in CheckDestroy could make the sweeping process better.