### PR TITLE
test(object): fix nightly ACL_Grantee

### DIFF
--- a/scaleway/resource_object_bucket_acl_test.go
+++ b/scaleway/resource_object_bucket_acl_test.go
@@ -79,29 +79,30 @@ func TestAccScalewayObjectBucketACL_Grantee(t *testing.T) {
 					resource "scaleway_object_bucket_acl" "main" {
 						bucket = scaleway_object_bucket.main.name
 						access_control_policy {
-						  grant {
-							grantee {
-								id   = "%[2]s"
-								type = "CanonicalUser"
-							}
-							permission = "FULL_CONTROL"
-						  }
+						  	grant {
+								grantee {
+									id   = "%[2]s"
+									type = "CanonicalUser"
+								}
+								permission = "FULL_CONTROL"
+						  	}
 						
-						  grant {
-							grantee {
-							  id   = "%[2]s"
-							  type = "CanonicalUser"
-							}
-							permission = "WRITE"
-						  }
+						  	grant {
+								grantee {
+							  		id   = "%[2]s"
+							  		type = "CanonicalUser"
+								}
+								permission = "WRITE"
+						  	}
 						
-						  owner {
-							id = "%[2]s"
-						  }
+						  	owner {
+								id = "%[2]s"
+						  	}
 						}
 					}
 					`, testBucketName, ownerID),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayObjectBucketExists(tt, "scaleway_object_bucket.main"),
 					resource.TestCheckResourceAttr("scaleway_object_bucket_acl.main", "bucket", testBucketName),
 				),
 			},
@@ -114,21 +115,38 @@ func TestAccScalewayObjectBucketACL_Grantee(t *testing.T) {
 					resource "scaleway_object_bucket_acl" "main" {
 						bucket = scaleway_object_bucket.main.name
 						access_control_policy {
+						  	grant {
+								grantee {
+									id   = "%[2]s"
+									type = "CanonicalUser"
+								}
+								permission = "FULL_CONTROL"
+						  	}
+						
+						  	grant {
+								grantee {
+							  		id   = "%[2]s"
+							  		type = "CanonicalUser"
+								}
+								permission = "WRITE"
+						  	}
+
 							grant {
 								grantee {
-								  id   = "%[3]s"
-								  type = "CanonicalUser"
+								  	id   = "%[3]s"
+								  	type = "CanonicalUser"
 								}
 								permission = "FULL_CONTROL"
 							}
 						
-							owner {
+						  	owner {
 								id = "%[2]s"
-							}
+						  	}
+						}
 					}
-				}
-					`, testBucketName, ownerID, ownerIDChild),
+				`, testBucketName, ownerID, ownerIDChild),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayObjectBucketExists(tt, "scaleway_object_bucket.main"),
 					resource.TestCheckResourceAttr("scaleway_object_bucket_acl.main", "bucket", testBucketName),
 				),
 			},

--- a/scaleway/testdata/object-bucket-acl-grantee.cassette.yaml
+++ b/scaleway/testdata/object-bucket-acl-grantee.cassette.yaml
@@ -8,7 +8,7 @@ interactions:
       Content-Length:
       - "150"
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Acl:
       - private
       X-Amz-Bucket-Object-Lock-Enabled:
@@ -16,24 +16,22 @@ interactions:
       X-Amz-Content-Sha256:
       - 2cb57fad7b7168921a4c94426cfcb9ee2953f126430595df844e22d50f029060
       X-Amz-Date:
-      - 20230228T101847Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
+      - 20231110T170750Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
     method: PUT
   response:
     body: ""
     headers:
       Content-Length:
       - "0"
-      Content-Type:
-      - text/html; charset=UTF-8
       Date:
-      - Tue, 28 Feb 2023 10:18:47 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       Location:
-      - /test-acc-scaleway-object-acl-grantee-5212564733028158638
+      - /test-acc-scaleway-object-acl-grantee-6366892773385556584
       X-Amz-Id-2:
-      - tx955640b6673e4723a0dfa-0063fdd507
+      - txgf59ad1304af84c55b09b-00654e6367
       X-Amz-Request-Id:
-      - tx955640b6673e4723a0dfa-0063fdd507
+      - txgf59ad1304af84c55b09b-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -44,14 +42,14 @@ interactions:
       Content-Md5:
       - 1B2M2Y8AsgTpgAmY7PhCfg==
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Acl:
       - private
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101847Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: PUT
   response:
     body: ""
@@ -61,11 +59,11 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Tue, 28 Feb 2023 10:18:47 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - txdcf8a06f4c294af09ae92-0063fdd507
+      - txe8cec72cd9544d2e839db-00654e6367
       X-Amz-Request-Id:
-      - txdcf8a06f4c294af09ae92-0063fdd507
+      - txe8cec72cd9544d2e839db-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -74,28 +72,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101847Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
       - "698"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:47 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - txb1a8880d4e44407b9f200-0063fdd507
+      - txg4c41cd9ddb6a4225ba75-00654e6367
       X-Amz-Request-Id:
-      - txb1a8880d4e44407b9f200-0063fdd507
+      - txg4c41cd9ddb6a4225ba75-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -104,84 +102,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101847Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?object-lock=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?object-lock=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>tx047dcee9070d48569a765-0063fdd507</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:47 GMT
-      X-Amz-Id-2:
-      - tx047dcee9070d48569a765-0063fdd507
-      X-Amz-Request-Id:
-      - tx047dcee9070d48569a765-0063fdd507
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101847Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-5212564733028158638</Name><Prefix/><Delimiter/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Marker/></ListBucketResult>
+    body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object
+      Lock configuration does not exist for this bucket</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgcf8f749fa27b43c3b901-00654e6367</RequestId></Error>
     headers:
       Content-Length:
-      - "278"
+      - "274"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - txd7b192e03eed43c98a0af-0063fdd507
+      - txgcf8f749fa27b43c3b901-00654e6367
       X-Amz-Request-Id:
-      - txd7b192e03eed43c98a0af-0063fdd507
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?tagging=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchTagSet</Code><Message>There is no tag set associated with the bucket or object.</Message><RequestId>txb391607d255d4c6bbaa33-0063fdd509</RequestId><Headers/></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
-      X-Amz-Id-2:
-      - txb391607d255d4c6bbaa33-0063fdd509
-      X-Amz-Request-Id:
-      - txb391607d255d4c6bbaa33-0063fdd509
+      - txgcf8f749fa27b43c3b901-00654e6367
     status: 404 Not Found
     code: 404
     duration: ""
@@ -190,56 +131,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?cors=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>tx3b4f5d61ed39486e8808f-0063fdd509</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
-      X-Amz-Id-2:
-      - tx3b4f5d61ed39486e8808f-0063fdd509
-      X-Amz-Request-Id:
-      - tx3b4f5d61ed39486e8808f-0063fdd509
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?versioning=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-6366892773385556584</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
     headers:
       Content-Length:
-      - "113"
+      - "282"
       Content-Type:
-      - text/plain
+      - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - txb71e8dc602804843818ac-0063fdd509
+      - txg651360c832e04ac29555-00654e6367
       X-Amz-Request-Id:
-      - txb71e8dc602804843818ac-0063fdd509
+      - txg651360c832e04ac29555-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -248,26 +161,114 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?lifecycle=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?tagging=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist.</Message><RequestId>txd6e6c38d67734df09e24d-0063fdd509</RequestId></Error>
+    body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgafb85a815f7b4468bc15-00654e6367</RequestId></Error>
     headers:
+      Content-Length:
+      - "219"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - txd6e6c38d67734df09e24d-0063fdd509
+      - txgafb85a815f7b4468bc15-00654e6367
       X-Amz-Request-Id:
-      - txd6e6c38d67734df09e24d-0063fdd509
+      - txgafb85a815f7b4468bc15-00654e6367
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?cors=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg41f89f26407246ccb880-00654e6367</RequestId></Error>
+    headers:
+      Content-Length:
+      - "242"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:51 GMT
+      X-Amz-Id-2:
+      - txg41f89f26407246ccb880-00654e6367
+      X-Amz-Request-Id:
+      - txg41f89f26407246ccb880-00654e6367
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?versioning=
+    method: GET
+  response:
+    body: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></VersioningConfiguration>
+    headers:
+      Content-Length:
+      - "138"
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 10 Nov 2023 17:07:51 GMT
+      X-Amz-Id-2:
+      - txgf3574ccfa1a646f5a8bf-00654e6367
+      X-Amz-Request-Id:
+      - txgf3574ccfa1a646f5a8bf-00654e6367
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?lifecycle=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg710ed1e5f01c4f4bbf7f-00654e6367</RequestId></Error>
+    headers:
+      Content-Length:
+      - "252"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:51 GMT
+      X-Amz-Id-2:
+      - txg710ed1e5f01c4f4bbf7f-00654e6367
+      X-Amz-Request-Id:
+      - txg710ed1e5f01c4f4bbf7f-00654e6367
     status: 404 Not Found
     code: 404
     duration: ""
@@ -282,12 +283,12 @@ interactions:
       Content-Md5:
       - hyolSq3koUeG8L+6oSV/Yw==
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - 894d438eed42dfd288716d6ff6a48b6be5515e9452ed58d924757813130fdf06
       X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: PUT
   response:
     body: ""
@@ -297,11 +298,11 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - tx8ba1c9b3501e41f19ea85-0063fdd509
+      - tx24cf5adede984a00bbcd7-00654e6367
       X-Amz-Request-Id:
-      - tx8ba1c9b3501e41f19ea85-0063fdd509
+      - tx24cf5adede984a00bbcd7-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -310,28 +311,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101849Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170751Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
       - "1023"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:49 GMT
+      - Fri, 10 Nov 2023 17:07:51 GMT
       X-Amz-Id-2:
-      - tx8cf56c5535754a78ba19f-0063fdd509
+      - txg8526238d57d14e9d8a5f-00654e6367
       X-Amz-Request-Id:
-      - tx8cf56c5535754a78ba19f-0063fdd509
+      - txg8526238d57d14e9d8a5f-00654e6367
     status: 200 OK
     code: 200
     duration: ""
@@ -340,28 +341,56 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101850Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:52 GMT
+      X-Amz-Bucket-Region:
+      - fr-par
+      X-Amz-Id-2:
+      - txgc596659b78e64f0db22b-00654e6368
+      X-Amz-Request-Id:
+      - txgc596659b78e64f0db22b-00654e6368
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
       - "1023"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:50 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - tx2317d8e8376d4b35bcb68-0063fdd50a
+      - txg339c45fbb46147dabcec-00654e6368
       X-Amz-Request-Id:
-      - tx2317d8e8376d4b35bcb68-0063fdd50a
+      - txg339c45fbb46147dabcec-00654e6368
     status: 200 OK
     code: 200
     duration: ""
@@ -370,84 +399,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101850Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?object-lock=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?object-lock=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>tx5b7c9364ba134f20a9d7f-0063fdd50a</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:50 GMT
-      X-Amz-Id-2:
-      - tx5b7c9364ba134f20a9d7f-0063fdd50a
-      X-Amz-Request-Id:
-      - tx5b7c9364ba134f20a9d7f-0063fdd50a
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101850Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-5212564733028158638</Name><Prefix/><Delimiter/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Marker/></ListBucketResult>
+    body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object
+      Lock configuration does not exist for this bucket</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgce53253dfa2e4218a750-00654e6368</RequestId></Error>
     headers:
       Content-Length:
-      - "278"
+      - "274"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:50 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - tx07f83547edd24ad191962-0063fdd50a
+      - txgce53253dfa2e4218a750-00654e6368
       X-Amz-Request-Id:
-      - tx07f83547edd24ad191962-0063fdd50a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101850Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?tagging=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchTagSet</Code><Message>There is no tag set associated with the bucket or object.</Message><RequestId>txeb4345a2dad749a6ae842-0063fdd50b</RequestId><Headers/></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:51 GMT
-      X-Amz-Id-2:
-      - txeb4345a2dad749a6ae842-0063fdd50b
-      X-Amz-Request-Id:
-      - txeb4345a2dad749a6ae842-0063fdd50b
+      - txgce53253dfa2e4218a750-00654e6368
     status: 404 Not Found
     code: 404
     duration: ""
@@ -456,56 +428,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101851Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?cors=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>tx3d87ea9d199249b4af74b-0063fdd50b</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:51 GMT
-      X-Amz-Id-2:
-      - tx3d87ea9d199249b4af74b-0063fdd50b
-      X-Amz-Request-Id:
-      - tx3d87ea9d199249b4af74b-0063fdd50b
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101851Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?versioning=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-6366892773385556584</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
     headers:
       Content-Length:
-      - "113"
+      - "282"
       Content-Type:
-      - text/plain
+      - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:51 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - tx4ada300fd4494db291c88-0063fdd50b
+      - txg66a87c4aaa474628b184-00654e6368
       X-Amz-Request-Id:
-      - tx4ada300fd4494db291c88-0063fdd50b
+      - txg66a87c4aaa474628b184-00654e6368
     status: 200 OK
     code: 200
     duration: ""
@@ -514,26 +458,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101851Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?lifecycle=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?tagging=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist.</Message><RequestId>txc0330ad9b18d4545b7d89-0063fdd50b</RequestId></Error>
+    body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg9ca4f616bd2a496689b8-00654e6368</RequestId></Error>
     headers:
+      Content-Length:
+      - "219"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:51 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - txc0330ad9b18d4545b7d89-0063fdd50b
+      - txg9ca4f616bd2a496689b8-00654e6368
       X-Amz-Request-Id:
-      - txc0330ad9b18d4545b7d89-0063fdd50b
+      - txg9ca4f616bd2a496689b8-00654e6368
     status: 404 Not Found
     code: 404
     duration: ""
@@ -542,28 +486,57 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101851Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?cors=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgfa5e780a7f174347b7b7-00654e6368</RequestId></Error>
+    headers:
+      Content-Length:
+      - "242"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:52 GMT
+      X-Amz-Id-2:
+      - txgfa5e780a7f174347b7b7-00654e6368
+      X-Amz-Request-Id:
+      - txgfa5e780a7f174347b7b7-00654e6368
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?versioning=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></VersioningConfiguration>
     headers:
       Content-Length:
-      - "1023"
+      - "138"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:51 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - txdad832d445bc40a8a9aac-0063fdd50b
+      - txgf22e5468657b4e818b04-00654e6368
       X-Amz-Request-Id:
-      - txdad832d445bc40a8a9aac-0063fdd50b
+      - txgf22e5468657b4e818b04-00654e6368
     status: 200 OK
     code: 200
     duration: ""
@@ -572,28 +545,57 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101851Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?lifecycle=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg8044858320894be4ba4b-00654e6368</RequestId></Error>
+    headers:
+      Content-Length:
+      - "252"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:52 GMT
+      X-Amz-Id-2:
+      - txg8044858320894be4ba4b-00654e6368
+      X-Amz-Request-Id:
+      - txg8044858320894be4ba4b-00654e6368
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
       - "1023"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - txd70fdb52f8044c649feac-0063fdd50c
+      - txg0f5439026afa407887f8-00654e6368
       X-Amz-Request-Id:
-      - txd70fdb52f8044c649feac-0063fdd50c
+      - txg0f5439026afa407887f8-00654e6368
     status: 200 OK
     code: 200
     duration: ""
@@ -602,219 +604,254 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?object-lock=
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txe67fb686989b4d938bf03-0063fdd50c</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - txe67fb686989b4d938bf03-0063fdd50c
-      X-Amz-Request-Id:
-      - txe67fb686989b4d938bf03-0063fdd50c
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-5212564733028158638</Name><Prefix/><Delimiter/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Marker/></ListBucketResult>
-    headers:
-      Content-Length:
-      - "278"
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - tx72715f21669f4d5da997f-0063fdd50c
-      X-Amz-Request-Id:
-      - tx72715f21669f4d5da997f-0063fdd50c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?tagging=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchTagSet</Code><Message>There is no tag set associated with the bucket or object.</Message><RequestId>txacb4ac9391454275956fb-0063fdd50c</RequestId><Headers/></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - txacb4ac9391454275956fb-0063fdd50c
-      X-Amz-Request-Id:
-      - txacb4ac9391454275956fb-0063fdd50c
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?cors=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>tx78dfbffb05de4dcc89369-0063fdd50c</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - tx78dfbffb05de4dcc89369-0063fdd50c
-      X-Amz-Request-Id:
-      - tx78dfbffb05de4dcc89369-0063fdd50c
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?versioning=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
-    headers:
-      Content-Length:
-      - "113"
-      Content-Type:
-      - text/plain
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - txa54fbe64c99943fdbb143-0063fdd50c
-      X-Amz-Request-Id:
-      - txa54fbe64c99943fdbb143-0063fdd50c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?lifecycle=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist.</Message><RequestId>tx5a517504939348c694522-0063fdd50c</RequestId></Error>
-    headers:
-      Content-Type:
-      - application/xml
-      Date:
-      - Tue, 28 Feb 2023 10:18:52 GMT
-      X-Amz-Id-2:
-      - tx5a517504939348c694522-0063fdd50c
-      X-Amz-Request-Id:
-      - tx5a517504939348c694522-0063fdd50c
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101852Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
       - "1023"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:53 GMT
+      - Fri, 10 Nov 2023 17:07:52 GMT
       X-Amz-Id-2:
-      - tx39e5fc84d58b4516995d6-0063fdd50d
+      - txge2952ad2683d4e9db1a4-00654e6368
       X-Amz-Request-Id:
-      - tx39e5fc84d58b4516995d6-0063fdd50d
+      - txge2952ad2683d4e9db1a4-00654e6368
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170752Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?object-lock=
+    method: GET
+  response:
+    body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object
+      Lock configuration does not exist for this bucket</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txge8ad702ad4cc4e4f929a-00654e6368</RequestId></Error>
+    headers:
+      Content-Length:
+      - "274"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:52 GMT
+      X-Amz-Id-2:
+      - txge8ad702ad4cc4e4f929a-00654e6368
+      X-Amz-Request-Id:
+      - txge8ad702ad4cc4e4f929a-00654e6368
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
+    method: GET
+  response:
+    body: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-6366892773385556584</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+    headers:
+      Content-Length:
+      - "282"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txg5adcba965df64f6d80a0-00654e6369
+      X-Amz-Request-Id:
+      - txg5adcba965df64f6d80a0-00654e6369
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?tagging=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgac81327e66ce41c8afcd-00654e6369</RequestId></Error>
+    headers:
+      Content-Length:
+      - "219"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txgac81327e66ce41c8afcd-00654e6369
+      X-Amz-Request-Id:
+      - txgac81327e66ce41c8afcd-00654e6369
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?cors=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgda2295cb2b7e41c690bf-00654e6369</RequestId></Error>
+    headers:
+      Content-Length:
+      - "242"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txgda2295cb2b7e41c690bf-00654e6369
+      X-Amz-Request-Id:
+      - txgda2295cb2b7e41c690bf-00654e6369
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?versioning=
+    method: GET
+  response:
+    body: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></VersioningConfiguration>
+    headers:
+      Content-Length:
+      - "138"
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txgb724f7de40744807a3a2-00654e6369
+      X-Amz-Request-Id:
+      - txgb724f7de40744807a3a2-00654e6369
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?lifecycle=
+    method: GET
+  response:
+    body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg353c85fb1d064282b5f9-00654e6369</RequestId></Error>
+    headers:
+      Content-Length:
+      - "252"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txg353c85fb1d064282b5f9-00654e6369
+      X-Amz-Request-Id:
+      - txg353c85fb1d064282b5f9-00654e6369
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
+    method: GET
+  response:
+    body: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+    headers:
+      Content-Length:
+      - "1023"
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Id-2:
+      - txg974363b1fbe94368aa89-00654e6369
+      X-Amz-Request-Id:
+      - txg974363b1fbe94368aa89-00654e6369
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><AccessControlList><Grant><Grantee
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner></AccessControlPolicy>
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Grantee><Permission>WRITE</Permission></Grant><Grant><Permission>FULL_CONTROL</Permission><Grantee
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID></Grantee></Grant><Grant><Grantee
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner></AccessControlPolicy>
     form: {}
     headers:
       Content-Length:
-      - "559"
+      - "1016"
       Content-Md5:
-      - UUqfw77vfDYEq8v3e1R6yg==
+      - 2wmIHyc5JZFYG95VSvW5jA==
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
-      - 6149521431c094350c190102c9b181073d3b5dafa075c606e1ad485f8d8cfb29
+      - e51881f45dbbb8c8c9fdd9e0b17df748b36ba0f91be63fbc14b2cda3f7d686b8
       X-Amz-Date:
-      - 20230228T101853Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: PUT
   response:
     body: ""
@@ -824,11 +861,11 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Tue, 28 Feb 2023 10:18:53 GMT
+      - Fri, 10 Nov 2023 17:07:53 GMT
       X-Amz-Id-2:
-      - txbb95d1e8a3194657bbf4b-0063fdd50d
+      - tx1fe9f421a79142a89c22e-00654e6369
       X-Amz-Request-Id:
-      - txbb95d1e8a3194657bbf4b-0063fdd50d
+      - tx1fe9f421a79142a89c22e-00654e6369
     status: 200 OK
     code: 200
     duration: ""
@@ -837,28 +874,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101853Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
-      - "698"
+      - "1355"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:53 GMT
+      - Fri, 10 Nov 2023 17:07:53 GMT
       X-Amz-Id-2:
-      - txe92399e42f934b4ebc6f3-0063fdd50d
+      - txg864116171a474881b975-00654e6369
       X-Amz-Request-Id:
-      - txe92399e42f934b4ebc6f3-0063fdd50d
+      - txg864116171a474881b975-00654e6369
     status: 200 OK
     code: 200
     duration: ""
@@ -867,56 +904,85 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
-    method: GET
+      - 20231110T170753Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
+    method: HEAD
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-    headers:
-      Content-Length:
-      - "698"
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
-      X-Amz-Id-2:
-      - tx8b488e329a6d4a3cab6c2-0063fdd50e
-      X-Amz-Request-Id:
-      - tx8b488e329a6d4a3cab6c2-0063fdd50e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?object-lock=
-    method: GET
-  response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>tx33528d5edb4f4eda9da38-0063fdd50e</RequestId></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:53 GMT
+      X-Amz-Bucket-Region:
+      - fr-par
       X-Amz-Id-2:
-      - tx33528d5edb4f4eda9da38-0063fdd50e
+      - txgeecae0a92f7b48ddbed4-00654e6369
       X-Amz-Request-Id:
-      - tx33528d5edb4f4eda9da38-0063fdd50e
+      - txgeecae0a92f7b48ddbed4-00654e6369
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
+    method: GET
+  response:
+    body: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+    headers:
+      Content-Length:
+      - "1355"
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 10 Nov 2023 17:07:54 GMT
+      X-Amz-Id-2:
+      - txg59b618190b4143e0a208-00654e636a
+      X-Amz-Request-Id:
+      - txg59b618190b4143e0a208-00654e636a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?object-lock=
+    method: GET
+  response:
+    body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object
+      Lock configuration does not exist for this bucket</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg49141bef387d4dc2bd83-00654e636a</RequestId></Error>
+    headers:
+      Content-Length:
+      - "274"
+      Content-Type:
+      - application/xml
+      Date:
+      - Fri, 10 Nov 2023 17:07:54 GMT
+      X-Amz-Id-2:
+      - txg49141bef387d4dc2bd83-00654e636a
+      X-Amz-Request-Id:
+      - txg49141bef387d4dc2bd83-00654e636a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -925,28 +991,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-5212564733028158638</Name><Prefix/><Delimiter/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Marker/></ListBucketResult>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test-acc-scaleway-object-acl-grantee-6366892773385556584</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
     headers:
       Content-Length:
-      - "278"
+      - "282"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txbcbcd64c1493401dbfa55-0063fdd50e
+      - txgdb032d0aadc54f678834-00654e636a
       X-Amz-Request-Id:
-      - txbcbcd64c1493401dbfa55-0063fdd50e
+      - txgdb032d0aadc54f678834-00654e636a
     status: 200 OK
     code: 200
     duration: ""
@@ -955,26 +1021,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?tagging=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?tagging=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchTagSet</Code><Message>There is no tag set associated with the bucket or object.</Message><RequestId>txd0ccbfcfd16e4e6d82a9a-0063fdd50e</RequestId><Headers/></Error>
+    body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txgaeb63bed91d94921a5da-00654e636a</RequestId></Error>
     headers:
+      Content-Length:
+      - "219"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txd0ccbfcfd16e4e6d82a9a-0063fdd50e
+      - txgaeb63bed91d94921a5da-00654e636a
       X-Amz-Request-Id:
-      - txd0ccbfcfd16e4e6d82a9a-0063fdd50e
+      - txgaeb63bed91d94921a5da-00654e636a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -983,26 +1049,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?cors=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?cors=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txfea0d5e5703e45cdbf5a0-0063fdd50e</RequestId></Error>
+    body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg93264f23d094436fb698-00654e636a</RequestId></Error>
     headers:
+      Content-Length:
+      - "242"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txfea0d5e5703e45cdbf5a0-0063fdd50e
+      - txg93264f23d094436fb698-00654e636a
       X-Amz-Request-Id:
-      - txfea0d5e5703e45cdbf5a0-0063fdd50e
+      - txg93264f23d094436fb698-00654e636a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1011,28 +1078,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?versioning=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?versioning=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></VersioningConfiguration>
     headers:
       Content-Length:
-      - "113"
+      - "138"
       Content-Type:
-      - text/plain
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - tx2fc4667db0234c808155d-0063fdd50e
+      - txg761bf3263bc44abf9a76-00654e636a
       X-Amz-Request-Id:
-      - tx2fc4667db0234c808155d-0063fdd50e
+      - txg761bf3263bc44abf9a76-00654e636a
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,26 +1108,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?lifecycle=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?lifecycle=
     method: GET
   response:
-    body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist.</Message><RequestId>txba095883d8b2442a95e6b-0063fdd50e</RequestId></Error>
+    body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration
+      does not exist</Message><Resource>/test-acc-scaleway-object-acl-grantee-6366892773385556584</Resource><RequestId>txg312f987ed3f24da1a4b9-00654e636a</RequestId></Error>
     headers:
+      Content-Length:
+      - "252"
       Content-Type:
       - application/xml
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txba095883d8b2442a95e6b-0063fdd50e
+      - txg312f987ed3f24da1a4b9-00654e636a
       X-Amz-Request-Id:
-      - txba095883d8b2442a95e6b-0063fdd50e
+      - txg312f987ed3f24da1a4b9-00654e636a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1069,28 +1137,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101854Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
-      - "698"
+      - "1355"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:54 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txbdb6bc10a8444497a55be-0063fdd50e
+      - txge2e03ea189f94e3da4d9-00654e636a
       X-Amz-Request-Id:
-      - txbdb6bc10a8444497a55be-0063fdd50e
+      - txge2e03ea189f94e3da4d9-00654e636a
     status: 200 OK
     code: 200
     duration: ""
@@ -1099,28 +1167,28 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101855Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/?acl=
+      - 20231110T170754Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/?acl=
     method: GET
   response:
     body: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</ID><DisplayName>50ab77d5-56bd-4981-a118-4e0fa5309b59:50ab77d5-56bd-4981-a118-4e0fa5309b59</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
     headers:
       Content-Length:
-      - "698"
+      - "1355"
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=utf-8
       Date:
-      - Tue, 28 Feb 2023 10:18:55 GMT
+      - Fri, 10 Nov 2023 17:07:54 GMT
       X-Amz-Id-2:
-      - txc9e2b74d84054263a142d-0063fdd50f
+      - txgbc37accf77b440e6820a-00654e636a
       X-Amz-Request-Id:
-      - txc9e2b74d84054263a142d-0063fdd50f
+      - txgbc37accf77b440e6820a-00654e636a
     status: 200 OK
     code: 200
     duration: ""
@@ -1129,12 +1197,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - aws-sdk-go/1.44.193 (go1.19.5; darwin; amd64)
+      - aws-sdk-go/1.47.1 (go1.20.4; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20230228T101855Z
-    url: https://test-acc-scaleway-object-acl-grantee-5212564733028158638.s3.fr-par.scw.cloud/
+      - 20231110T170755Z
+    url: https://test-acc-scaleway-object-acl-grantee-6366892773385556584.s3.fr-par.scw.cloud/
     method: DELETE
   response:
     body: ""
@@ -1144,11 +1212,11 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Tue, 28 Feb 2023 10:18:56 GMT
+      - Fri, 10 Nov 2023 17:07:55 GMT
       X-Amz-Id-2:
-      - tx40b6dccac99d4bf7b60e7-0063fdd50f
+      - tx8909480ef7d84da5bf1ee-00654e636b
       X-Amz-Request-Id:
-      - tx40b6dccac99d4bf7b60e7-0063fdd50f
+      - tx8909480ef7d84da5bf1ee-00654e636b
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
TestAccScalewayObjectBucketACL_Grantee was failing because the second step used to overwrite the previous ACL, stripping the owner of his rights. This PR adds the owner to the second step's ACL.